### PR TITLE
fix: uodpornienie kreskowania

### DIFF
--- a/src/simple_gml_import.py
+++ b/src/simple_gml_import.py
@@ -455,22 +455,22 @@ class SimpleGmlImport():
                 for sc in scales:
                     nr += 1
                     for lay in vec_layers_list:
-                        if 'ot_obiekttrwalezwiazany' in lay.name().lower():
+                        if 'egb_obiekttrwalezwiazany' in lay.name().lower() and egb_polyline_layer_id:
+                            calculateHatching(lay, 'schody', sc, egb_polyline_layer_id)
+                        elif 'ot_obiekttrwalezwiazany' in lay.name().lower() and ot_polyline_layer_id:
                             calculateHatching(lay, 'schody', sc, ot_polyline_layer_id)
-                        elif 'egb_obiekttrwalezwiazany' in lay.name().lower():
-                                calculateHatching(lay, 'schody', sc, egb_polyline_layer_id)
-                        elif 'komunikacja' in lay.name().lower():
+                        elif 'komunikacja' in lay.name().lower() and ot_polyline_layer_id:
                             calculateHatching(lay, 'schody', sc, ot_polyline_layer_id)
-                        elif 'budowle' in lay.name().lower():
+                        elif 'budowle' in lay.name().lower() and ot_polyline_layer_id:
                             calculateHatching(lay, 'sciana', sc, ot_polyline_layer_id)
 
 
                         if sc == '500':
                             if 'ges_rzedna' in lay.name().lower():
                                 calculateColors(lay, 'color')
-                            elif 'wody' in lay.name().lower():
+                            elif 'wody' in lay.name().lower() and start_point_layer_id and end_point_layer_id:
                                 calculateHatching(lay, 'wody', sc, [start_point_layer_id, end_point_layer_id])
-                            elif 'skarpa' in lay.name().lower():
+                            elif 'skarpa' in lay.name().lower() and start_point_layer_id and end_point_layer_id:
                                 calculateHatching(lay, 'skarpa', sc, [start_point_layer_id, end_point_layer_id])
 
                         elif sc == '1000':

--- a/stylization/1000/polygon/EGB_ObiektTrwaleZwiazanyZBudynkiem.qml
+++ b/stylization/1000/polygon/EGB_ObiektTrwaleZwiazanyZBudynkiem.qml
@@ -1,1695 +1,1266 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{4402cd2b-a26f-44a1-a5bc-6664c7967240}">
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 't'" symbol="0" label="taras" key="{fa065e21-bd4d-4b32-95d5-1b14a396186a}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'w'" symbol="1" label="weranda, ganek" key="{b11b6b99-f24c-4dac-b2ad-a96f9f2699b1}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'i'" symbol="2" label="wiatrołap" key="{795ad3ec-f7a8-4344-9278-b74b6547559f}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 's' " symbol="3" label="schody" key="{e6a48dbe-d88a-4145-8f15-f63854030b37}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'o'" symbol="4" label="podpora" key="{0d857496-54b8-4ece-bc37-2c0a3ad07e4f}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'r'" symbol="5" label="rampa" key="{4f92aea1-46ea-40bd-91e8-1f71bc3cabf3}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'j'" symbol="6" label="wjazd do podziemia" key="{7446eccf-4e2d-4a13-8113-61a5ba239d4c}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'd'" symbol="7" label="podjazd dla osób niepełnosprawnych" key="{89f057ff-ee2b-43fb-b41f-67e5a58b4ef6}" />
-      <rule filter="ELSE" symbol="8" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}" />
+      <rule symbol="0" key="{fa065e21-bd4d-4b32-95d5-1b14a396186a}" label="taras" filter="rodzajObiektuZwiazanegoZBudynkiem = 't'"/>
+      <rule symbol="1" key="{b11b6b99-f24c-4dac-b2ad-a96f9f2699b1}" label="weranda, ganek" filter="rodzajObiektuZwiazanegoZBudynkiem = 'w'"/>
+      <rule symbol="2" key="{795ad3ec-f7a8-4344-9278-b74b6547559f}" label="wiatrołap" filter="rodzajObiektuZwiazanegoZBudynkiem = 'i'"/>
+      <rule symbol="3" key="{e6a48dbe-d88a-4145-8f15-f63854030b37}" label="schody" filter="rodzajObiektuZwiazanegoZBudynkiem = 's' "/>
+      <rule symbol="4" key="{0d857496-54b8-4ece-bc37-2c0a3ad07e4f}" label="podpora" filter="rodzajObiektuZwiazanegoZBudynkiem = 'o'"/>
+      <rule symbol="5" key="{4f92aea1-46ea-40bd-91e8-1f71bc3cabf3}" label="rampa" filter="rodzajObiektuZwiazanegoZBudynkiem = 'r'"/>
+      <rule symbol="6" key="{7446eccf-4e2d-4a13-8113-61a5ba239d4c}" label="wjazd do podziemia" filter="rodzajObiektuZwiazanegoZBudynkiem = 'j'"/>
+      <rule symbol="7" key="{89f057ff-ee2b-43fb-b41f-67e5a58b4ef6}" label="podjazd dla osób niepełnosprawnych" filter="rodzajObiektuZwiazanegoZBudynkiem = 'd'"/>
+      <rule symbol="8" key="{427914c2-1048-4e08-b88d-475ca325312a}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{aa6f60d9-be00-4623-8fe8-0caef9804d30}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{760b7caa-3753-456d-8fa1-8489b47ad2b3}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.75" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.75" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.75" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{198d76b5-91c5-4cf9-837f-8bcc9a173f67}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.75;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.75" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.75;0.75" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.75" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.75;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.75" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{f7ab113a-4077-4c1b-b837-97ed11bb0a83}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" id="{e165d39b-95b8-4570-9df2-b13aa8aaefe2}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MapUnit" />
-            <Option name="interval" type="QString" value="0.75" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="Interval" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option name="average_angle_length" value="4" type="QString"/>
+            <Option name="average_angle_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="average_angle_unit" value="MapUnit" type="QString"/>
+            <Option name="interval" value="0.75" type="QString"/>
+            <Option name="interval_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="interval_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_along_line" value="0" type="QString"/>
+            <Option name="offset_along_line_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="offset_along_line_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="place_on_every_part" value="true" type="bool"/>
+            <Option name="placements" value="Interval" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="rotate" value="1" type="QString"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MapUnit" k="average_angle_unit" />
-          <prop v="0.75" k="interval" />
-          <prop v="3x:5000,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="Interval" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@2@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{c7b56b86-537c-4f08-80be-702414557b33}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="35,35,35,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.18" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.18" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.18" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.18" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="35,35,35,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.18" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.18" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{bfb8ddaf-6f6a-41d0-85d4-29fb53e987f8}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{25640cda-3d03-4a1d-a610-7df5c689eee3}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_1000&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_1000'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_1000&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@3@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@3@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{f5db580e-b500-4ac9-9ad6-cdf26efe1d76}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{b27af5a3-c1af-489b-9070-b5019658f3b8}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{67baeed5-237c-40ea-9758-c50edee86dd8}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{5d9923b1-a649-45de-a34a-b7aaa99b76b6}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{34ccf5ea-04d3-4be9-8072-01d9bc76f73f}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="PointPatternFill" pass="0" enabled="1">
+        <layer class="PointPatternFill" id="{194595ad-51a1-492f-982e-ba2eae15e4ec}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="angle" type="double" value="0" />
-            <Option name="clip_mode" type="QString" value="shape" />
-            <Option name="coordinate_reference" type="QString" value="feature" />
-            <Option name="displacement_x" type="QString" value="0.75" />
-            <Option name="displacement_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="displacement_x_unit" type="QString" value="MapUnit" />
-            <Option name="displacement_y" type="QString" value="0" />
-            <Option name="displacement_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="displacement_y_unit" type="QString" value="MapUnit" />
-            <Option name="distance_x" type="QString" value="1.5" />
-            <Option name="distance_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="distance_x_unit" type="QString" value="MapUnit" />
-            <Option name="distance_y" type="QString" value="1.5" />
-            <Option name="distance_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="distance_y_unit" type="QString" value="MapUnit" />
-            <Option name="offset_x" type="QString" value="0" />
-            <Option name="offset_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_x_unit" type="QString" value="MapUnit" />
-            <Option name="offset_y" type="QString" value="0" />
-            <Option name="offset_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_y_unit" type="QString" value="MapUnit" />
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="random_deviation_x" type="QString" value="0" />
-            <Option name="random_deviation_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="random_deviation_x_unit" type="QString" value="MM" />
-            <Option name="random_deviation_y" type="QString" value="0" />
-            <Option name="random_deviation_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="random_deviation_y_unit" type="QString" value="MM" />
-            <Option name="seed" type="QString" value="848809716" />
+            <Option name="angle" value="0" type="double"/>
+            <Option name="clip_mode" value="shape" type="QString"/>
+            <Option name="coordinate_reference" value="feature" type="QString"/>
+            <Option name="displacement_x" value="0.75" type="QString"/>
+            <Option name="displacement_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_x_unit" value="MapUnit" type="QString"/>
+            <Option name="displacement_y" value="0" type="QString"/>
+            <Option name="displacement_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_y_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_x" value="1.5" type="QString"/>
+            <Option name="distance_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_x_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_y" value="1.5" type="QString"/>
+            <Option name="distance_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_y_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_x" value="0" type="QString"/>
+            <Option name="offset_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_x_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_y" value="0" type="QString"/>
+            <Option name="offset_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_y_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="random_deviation_x" value="0" type="QString"/>
+            <Option name="random_deviation_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_x_unit" value="MM" type="QString"/>
+            <Option name="random_deviation_y" value="0" type="QString"/>
+            <Option name="random_deviation_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_y_unit" value="MM" type="QString"/>
+            <Option name="seed" value="848809716" type="QString"/>
           </Option>
-          <prop v="0" k="angle" />
-          <prop v="shape" k="clip_mode" />
-          <prop v="feature" k="coordinate_reference" />
-          <prop v="0.75" k="displacement_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="displacement_x_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_x_unit" />
-          <prop v="0" k="displacement_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="displacement_y_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_y_unit" />
-          <prop v="1.5" k="distance_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="distance_x_map_unit_scale" />
-          <prop v="MapUnit" k="distance_x_unit" />
-          <prop v="1.5" k="distance_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="distance_y_map_unit_scale" />
-          <prop v="MapUnit" k="distance_y_unit" />
-          <prop v="0" k="offset_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_x_map_unit_scale" />
-          <prop v="MapUnit" k="offset_x_unit" />
-          <prop v="0" k="offset_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_y_map_unit_scale" />
-          <prop v="MapUnit" k="offset_y_unit" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="0" k="random_deviation_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="random_deviation_x_map_unit_scale" />
-          <prop v="MM" k="random_deviation_x_unit" />
-          <prop v="0" k="random_deviation_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="random_deviation_y_map_unit_scale" />
-          <prop v="MM" k="random_deviation_y_unit" />
-          <prop v="848809716" k="seed" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@6@1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{5bc2527a-8dde-4964-b78f-153a9537e9d4}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="35,35,35,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.18" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.18" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.18" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.18" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="35,35,35,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.18" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.18" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{6860eb0b-7ec7-400c-a449-5b05de1086e2}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{a6bbbffc-5d9d-4cf5-a0a3-7ea9e6f54892}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.1" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.1" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:5000,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.1" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{dae818c0-f04e-4de1-8c74-dec6d872be44}">
       <settings calloutType="simple">
-        <text-style fontWeight="50" fontSizeUnit="Point" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="" allowHtml="0" fieldName="" fontSize="10" fontItalic="0" fontFamily="MS Shell Dlg 2" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="0">
-          <families />
-          <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-          <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-          <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-            <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+        <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="Point" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="" fieldName="" isExpression="0" fontSize="10" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="MS Shell Dlg 2" legendString="Aa" fontSizeMapUnitScale="3x:0,0,0,0,0,0" tabStopDistance="80">
+          <families/>
+          <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+          <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+          <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+            <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" />
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+              <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                 <Option type="Map">
-                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                  <Option name="color" type="QString" value="255,255,255,255" />
-                  <Option name="joinstyle" type="QString" value="bevel" />
-                  <Option name="offset" type="QString" value="0,0" />
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                  <Option name="offset_unit" type="QString" value="MM" />
-                  <Option name="outline_color" type="QString" value="128,128,128,255" />
-                  <Option name="outline_style" type="QString" value="no" />
-                  <Option name="outline_width" type="QString" value="0" />
-                  <Option name="outline_width_unit" type="QString" value="MM" />
-                  <Option name="style" type="QString" value="solid" />
+                  <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="offset" value="0,0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                  <Option name="outline_style" value="no" type="QString"/>
+                  <Option name="outline_width" value="0" type="QString"/>
+                  <Option name="outline_width_unit" value="MM" type="QString"/>
+                  <Option name="style" value="solid" type="QString"/>
                 </Option>
-                <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                <prop v="255,255,255,255" k="color" />
-                <prop v="bevel" k="joinstyle" />
-                <prop v="0,0" k="offset" />
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                <prop v="MM" k="offset_unit" />
-                <prop v="128,128,128,255" k="outline_color" />
-                <prop v="no" k="outline_style" />
-                <prop v="0" k="outline_width" />
-                <prop v="MM" k="outline_width_unit" />
-                <prop v="solid" k="style" />
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </background>
-          <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+          <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
-          <substitutions />
+          <substitutions/>
         </text-style>
-        <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-        <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="0" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="UnknownGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-        <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="0" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+        <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+        <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="PreventOverlap" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="0" distUnits="MM" prioritization="PreferCloser" layerType="UnknownGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+        <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="0" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
         <dd_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </dd_properties>
         <callout type="simple">
           <Option type="Map">
-            <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-            <Option name="blendMode" type="int" value="0" />
+            <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+            <Option name="blendMode" value="0" type="int"/>
             <Option name="ddProperties" type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
-            <Option name="drawToAllParts" type="bool" value="false" />
-            <Option name="enabled" type="QString" value="0" />
-            <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-            <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-            <Option name="minLength" type="double" value="0" />
-            <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="minLengthUnit" type="QString" value="MM" />
-            <Option name="offsetFromAnchor" type="double" value="0" />
-            <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-            <Option name="offsetFromLabel" type="double" value="0" />
-            <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+            <Option name="drawToAllParts" value="false" type="bool"/>
+            <Option name="enabled" value="0" type="QString"/>
+            <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+            <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{58c0dd9d-c3c1-4146-8c59-7a7047841776}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+            <Option name="minLength" value="0" type="double"/>
+            <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="minLengthUnit" value="MM" type="QString"/>
+            <Option name="offsetFromAnchor" value="0" type="double"/>
+            <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+            <Option name="offsetFromLabel" value="0" type="double"/>
+            <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
           </Option>
         </callout>
       </settings>
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'r'" key="{0aed850a-8fc2-4be1-9137-c51d5ce8fc12}">
+      <rule key="{0aed850a-8fc2-4be1-9137-c51d5ce8fc12}" filter="rodzajObiektuZwiazanegoZBudynkiem = 'r'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'rmp'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'rmp'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="114,155,111,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="35,35,35,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="114,155,111,255,rgb:0.44705882352941179,0.60784313725490191,0.43529411764705883,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="114,155,111,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="35,35,35,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{310df67c-f01f-4873-a76c-ad026da5463d}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 'd'" key="{ad36a39a-7d69-43f8-b75d-d5fe086e707c}">
+      <rule key="{ad36a39a-7d69-43f8-b75d-d5fe086e707c}" filter="rodzajObiektuZwiazanegoZBudynkiem = 'd'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'n'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'n'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="190,207,80,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="35,35,35,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="190,207,80,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="35,35,35,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{22efbe0c-7ed1-46a8-8fa5-2666d5ad3421}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="QString" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/1000/polygon/OT_Budowle.qml
+++ b/stylization/1000/polygon/OT_Budowle.qml
@@ -1,3229 +1,2452 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.40.4-Bratislava" styleCategories="Symbology|Labeling" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" forceraster="0" symbollevels="0" referencescale="-1">
     <rules key="{e5e65104-337a-4815-b02f-0ddfff356ac4}">
-      <rule filter="rodzajBudowli = 'a'" symbol="0" label="wiata" key="{ce1a7bd9-f142-4f17-bdb3-ad1de9ae3bdb}" />
-      <rule filter="rodzajBudowli = 'm'" symbol="1" label="smietnik" key="{e74756c1-7065-4ef2-988e-61ad015ca0f0}" />
-      <rule filter="rodzajBudowli = 'n'" symbol="2" label="sciana oporowa" key="{49172e5a-5a66-443c-a040-20b7350a393d}" />
-      <rule filter="rodzajBudowli = 'd'" symbol="3" label="podpora" key="{cbc365f9-2b42-41e1-8ef3-17c96035634f}" />
-      <rule filter="rodzajBudowli = 't'" symbol="4" label="fontanna" key="{12584cfb-5305-4cf2-a85d-21ba4bf6ee3b}" />
-      <rule filter="rodzajBudowli = 'p'" symbol="5" label="pomnik" key="{43f859f0-a73d-4ecb-9564-c5e486774bc1}" />
-      <rule filter="rodzajBudowli = 'r'" symbol="6" label="ruina zabytkowa" key="{8c29ea65-b968-444a-8171-eb3808299fd3}" />
-      <rule filter="rodzajBudowli = 'c'" symbol="7" label="wieża ciśnień" key="{7753146a-c707-4631-92b0-f67f66dc4842}" />
-      <rule filter="rodzajBudowli = 'z'" symbol="8" label="wieża przeciwpożarowa" key="{a0d4ce62-aefc-4a83-be48-65386fc4758c}" />
-      <rule filter="rodzajBudowli = 's'" symbol="9" label="wieża szybu kopalnianego" key="{2f128911-1bdc-4cbc-bccd-1362630969b0}" />
-      <rule filter="rodzajBudowli = 'w'" symbol="10" label="wieża widokowa" key="{785319ab-d716-41bd-91c1-c83bd09dcc26}" />
-      <rule filter="rodzajBudowli = 'b'" symbol="11" label="zbiornik, silos" key="{f92c1d15-b371-4b1d-94c9-d531d7274189}" />
-      <rule filter="rodzajBudowli = 'k'" symbol="12" label="chłodnia kominowa" key="{b991ec28-22ba-4a64-97be-d635ba303766}" />
-      <rule filter="rodzajBudowli = 'o'" symbol="13" label="komin przemysłowy" key="{54557e94-64b7-455a-8f99-0f793165ebb4}" />
-      <rule filter="rodzajBudowli = 'i'" symbol="14" label="inna budowla" key="{cc728e06-74a6-463c-93a6-dc175d0c283b}" />
-      <rule filter="ELSE" symbol="15" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}" />
+      <rule symbol="0" filter="rodzajBudowli = 'a'" label="wiata" key="{ce1a7bd9-f142-4f17-bdb3-ad1de9ae3bdb}"/>
+      <rule symbol="1" filter="rodzajBudowli = 'm'" label="smietnik" key="{e74756c1-7065-4ef2-988e-61ad015ca0f0}"/>
+      <rule symbol="2" filter="rodzajBudowli = 'n'" label="sciana oporowa" key="{49172e5a-5a66-443c-a040-20b7350a393d}"/>
+      <rule symbol="3" filter="rodzajBudowli = 'd'" label="podpora" key="{cbc365f9-2b42-41e1-8ef3-17c96035634f}"/>
+      <rule symbol="4" filter="rodzajBudowli = 't'" label="fontanna" key="{12584cfb-5305-4cf2-a85d-21ba4bf6ee3b}"/>
+      <rule symbol="5" filter="rodzajBudowli = 'p'" label="pomnik" key="{43f859f0-a73d-4ecb-9564-c5e486774bc1}"/>
+      <rule symbol="6" filter="rodzajBudowli = 'r'" label="ruina zabytkowa" key="{8c29ea65-b968-444a-8171-eb3808299fd3}"/>
+      <rule symbol="7" filter="rodzajBudowli = 'c'" label="wieża ciśnień" key="{7753146a-c707-4631-92b0-f67f66dc4842}"/>
+      <rule symbol="8" filter="rodzajBudowli = 'z'" label="wieża przeciwpożarowa" key="{a0d4ce62-aefc-4a83-be48-65386fc4758c}"/>
+      <rule symbol="9" filter="rodzajBudowli = 's'" label="wieża szybu kopalnianego" key="{2f128911-1bdc-4cbc-bccd-1362630969b0}"/>
+      <rule symbol="10" filter="rodzajBudowli = 'w'" label="wieża widokowa" key="{785319ab-d716-41bd-91c1-c83bd09dcc26}"/>
+      <rule symbol="11" filter="rodzajBudowli = 'b'" label="zbiornik, silos" key="{f92c1d15-b371-4b1d-94c9-d531d7274189}"/>
+      <rule symbol="12" filter="rodzajBudowli = 'k'" label="chłodnia kominowa" key="{b991ec28-22ba-4a64-97be-d635ba303766}"/>
+      <rule symbol="13" filter="rodzajBudowli = 'o'" label="komin przemysłowy" key="{54557e94-64b7-455a-8f99-0f793165ebb4}"/>
+      <rule symbol="14" filter="rodzajBudowli = 'i'" label="inna budowla" key="{cc728e06-74a6-463c-93a6-dc175d0c283b}"/>
+      <rule symbol="15" filter="ELSE" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="0" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{9237b0a5-00d9-44ff-8197-fcf8396e1a5b}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1.5;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="1.5;0.75" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.18" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="1" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1.5;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" pass="0" id="{97ef11e7-f67e-484e-8cdf-3ca9eb051054}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MM" />
-            <Option name="interval" type="QString" value="3" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.375" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="FirstVertex" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="3" name="interval"/>
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="interval_unit"/>
+            <Option type="QString" value="0.375" name="offset"/>
+            <Option type="QString" value="0" name="offset_along_line"/>
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="FirstVertex" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MM" k="average_angle_unit" />
-          <prop v="3" k="interval" />
-          <prop v="3x:5000,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.375" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="FirstVertex" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@0@1" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" pass="0" id="{692be851-759f-432f-8266-2663a009a29e}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="255,0,0,0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="square" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.18" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.75" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="round" name="cap_style"/>
+                <Option type="QString" value="255,0,0,0,rgb:1,0,0,0" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="round" name="joinstyle"/>
+                <Option type="QString" value="square" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.18" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="0.75" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="255,0,0,0" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="square" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.18" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.75" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" pass="0" id="{fc84e1ce-1233-4f7a-a1b3-4c45bcf13907}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MM" />
-            <Option name="interval" type="QString" value="3" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.375" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="InnerVertices" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="3" name="interval"/>
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="interval_unit"/>
+            <Option type="QString" value="0.375" name="offset"/>
+            <Option type="QString" value="0" name="offset_along_line"/>
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="InnerVertices" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MM" k="average_angle_unit" />
-          <prop v="3" k="interval" />
-          <prop v="3x:5000,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.375" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="InnerVertices" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@2" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@0@2" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" pass="0" id="{afcb5f2b-9d83-46d2-b8cc-0551e8b153b7}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="45" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="255,0,0,0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="square" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.18" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.75" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="45" name="angle"/>
+                <Option type="QString" value="round" name="cap_style"/>
+                <Option type="QString" value="255,0,0,0,rgb:1,0,0,0" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="round" name="joinstyle"/>
+                <Option type="QString" value="square" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.18" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="0.75" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="45" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="255,0,0,0" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="square" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.18" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.75" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="1" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{673fc222-4306-4fb3-98d0-590b03edc19b}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="10" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="10" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{eeb9d9db-4d09-431c-9863-ee7d05440d42}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="11" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="11" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{cd759382-56e4-4090-9d6c-4acc7a47b16a}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.18" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="12" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="12" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{3e5493fd-2f3b-48df-b892-084e9031541f}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.75" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.18" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0.75" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.75" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{a571308d-953e-47ad-b0d2-9e89c392f7a2}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="13" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="13" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" pass="0" id="{d99fdefd-a71d-4535-993a-0bab9861ee60}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="color" type="QString" value="0,0,0,255" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,0,0,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.18" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.18" name="outline_width"/>
+            <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
           </Option>
-          <prop v="3x:5000,0,0,0.03,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,0,0,255" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,0,0,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.18" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="fillColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="fillColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="14" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="14" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{833ac83e-e1ca-4fa6-8379-f3943a88bcd8}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.18" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="15" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="15" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" pass="0" id="{d46e5e9a-28d8-4313-b45d-e43af8995718}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.1" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option type="QString" value="3x:5000,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" name="color"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.1" name="outline_width"/>
+            <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
           </Option>
-          <prop v="3x:5000,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.1" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="2" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" pass="0" id="{16e16d1b-f69f-49ef-8d4e-409cf1bf2e2c}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_1000&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option type="QString" value="Line" name="SymbolType"/>
+            <Option type="QString" value="geom_from_wkt(attribute('obliczona_geometria_1000'))" name="geometryModifier"/>
+            <Option type="QString" value="MapUnit" name="units"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_1000&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="line" name="@2@0" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" pass="0" id="{a414ac43-894b-4614-9634-991b84b39438}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="round" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="round" name="joinstyle"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.18" name="line_width"/>
+                <Option type="QString" value="MapUnit" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{2bd6e92b-ef10-4f35-8c50-a15341876d05}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.18" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="3" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{3b96deab-3c78-4882-80dd-e06b2dfc36cd}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.18" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="4" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{5efeb64d-a5ed-439c-a801-d21accb3964c}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="CentroidFill" pass="0" enabled="1">
+        <layer class="CentroidFill" pass="0" id="{64bb395e-40f4-4316-a1e6-610e8411e342}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="clip_on_current_part_only" type="QString" value="0" />
-            <Option name="clip_points" type="QString" value="0" />
-            <Option name="point_on_all_parts" type="QString" value="1" />
-            <Option name="point_on_surface" type="QString" value="1" />
+            <Option type="QString" value="0" name="clip_on_current_part_only"/>
+            <Option type="QString" value="0" name="clip_points"/>
+            <Option type="QString" value="1" name="point_on_all_parts"/>
+            <Option type="QString" value="1" name="point_on_surface"/>
           </Option>
-          <prop v="0" k="clip_on_current_part_only" />
-          <prop v="0" k="clip_points" />
-          <prop v="1" k="point_on_all_parts" />
-          <prop v="1" k="point_on_surface" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@4@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@4@1" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SvgMarker" pass="0" enabled="1">
+            <layer class="SvgMarker" pass="0" id="{b184671e-c640-4fe0-8620-97a76f8a66ed}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="color" type="QString" value="255,0,0,255" />
-                <Option name="fixedAspectRatio" type="QString" value="0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="name" type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMy43MzI0OTk4bW0iCiAgIGhlaWdodD0iMS4yMTkxNjE5bW0iCiAgIHZpZXdCb3g9IjAgMCAzLjczMjQ5OTggMS4yMTkxNjE5IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczNzI4IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPVERUX3BvbGlnb25fMTAwMC5zdmciCiAgIHhtbG5zOmlua3NjYXBlPSJodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy9uYW1lc3BhY2VzL2lua3NjYXBlIgogICB4bWxuczpzb2RpcG9kaT0iaHR0cDovL3NvZGlwb2RpLnNvdXJjZWZvcmdlLm5ldC9EVEQvc29kaXBvZGktMC5kdGQiCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHNvZGlwb2RpOm5hbWVkdmlldwogICAgIGlkPSJuYW1lZHZpZXczNzMwIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgaW5rc2NhcGU6ZG9jdW1lbnQtdW5pdHM9Im1tIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpbmtzY2FwZTp6b29tPSI0Ni4yOTU4NDgiCiAgICAgaW5rc2NhcGU6Y3g9IjcuNzk3Njc1NSIKICAgICBpbmtzY2FwZTpjeT0iLTAuMzU2NDAzNDUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzgwOSIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzcyNSI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzgwMyI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzgwMSIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwNi4yNTQ1NCwtMjExLjE5OTEyKSI+CiAgICA8ZwogICAgICAgaWQ9ImczNzk5IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzgwMykiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3Ni43Mjg3MDksMzIyLjI5NDM5KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwNSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcyLjQsMzExLjgpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgMCwwLjcyMDAzMTU3IC0wLjI5OTkyNzEzLDEuNDQwMDYzMSAtMC44MTU2NDIyOSwxLjk2Mzc3MDIgLTEuMDg3NzkwNywyLjI0MDEzNiAtMS40MjAwMzE2LDIuNDYxODI5NyAtMS44LDIuNiAtMi45LDMgLTQuMiwyLjcgLTQuOSwxLjgiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjY4MDMxNSIKCQkgICBzdHJva2UtbGluZWNhcD0icm91bmQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKICAgICAgICAgICBpZD0icGF0aDM4MDciCiAgICAgICAgICAgc29kaXBvZGk6bm9kZXR5cGVzPSJjc3NjIiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwOSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc3LjQsMzEzLjYpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTAuOCwwLjkgLTIsMS4yIC0zLjIsMC44IC00LjMsMC40IC01LC0wLjcgLTUsLTEuOCIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNjgwMzE1IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzgxMSIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_width" type="QString" value="0" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="parameters" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="2.625" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="255,0,0,255,rgb:1,0,0,1" name="color"/>
+                <Option type="QString" value="0" name="fixedAspectRatio"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMy43MzI0OTk4bW0iCiAgIGhlaWdodD0iMS4yMTkxNjE5bW0iCiAgIHZpZXdCb3g9IjAgMCAzLjczMjQ5OTggMS4yMTkxNjE5IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczNzI4IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPVERUX3BvbGlnb25fMTAwMC5zdmciCiAgIHhtbG5zOmlua3NjYXBlPSJodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy9uYW1lc3BhY2VzL2lua3NjYXBlIgogICB4bWxuczpzb2RpcG9kaT0iaHR0cDovL3NvZGlwb2RpLnNvdXJjZWZvcmdlLm5ldC9EVEQvc29kaXBvZGktMC5kdGQiCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHNvZGlwb2RpOm5hbWVkdmlldwogICAgIGlkPSJuYW1lZHZpZXczNzMwIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgaW5rc2NhcGU6ZG9jdW1lbnQtdW5pdHM9Im1tIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpbmtzY2FwZTp6b29tPSI0Ni4yOTU4NDgiCiAgICAgaW5rc2NhcGU6Y3g9IjcuNzk3Njc1NSIKICAgICBpbmtzY2FwZTpjeT0iLTAuMzU2NDAzNDUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzgwOSIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzcyNSI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzgwMyI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzgwMSIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwNi4yNTQ1NCwtMjExLjE5OTEyKSI+CiAgICA8ZwogICAgICAgaWQ9ImczNzk5IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzgwMykiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3Ni43Mjg3MDksMzIyLjI5NDM5KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwNSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcyLjQsMzExLjgpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgMCwwLjcyMDAzMTU3IC0wLjI5OTkyNzEzLDEuNDQwMDYzMSAtMC44MTU2NDIyOSwxLjk2Mzc3MDIgLTEuMDg3NzkwNywyLjI0MDEzNiAtMS40MjAwMzE2LDIuNDYxODI5NyAtMS44LDIuNiAtMi45LDMgLTQuMiwyLjcgLTQuOSwxLjgiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjY4MDMxNSIKCQkgICBzdHJva2UtbGluZWNhcD0icm91bmQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKICAgICAgICAgICBpZD0icGF0aDM4MDciCiAgICAgICAgICAgc29kaXBvZGk6bm9kZXR5cGVzPSJjc3NjIiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwOSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc3LjQsMzEzLjYpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTAuOCwwLjkgLTIsMS4yIC0zLjIsMC44IC00LjMsMC40IC01LC0wLjcgLTUsLTEuOCIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNjgwMzE1IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzgxMSIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option name="parameters"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="2.625" name="size"/>
+                <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="255,0,0,255" k="color" />
-              <prop v="0" k="fixedAspectRatio" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMy43MzI0OTk4bW0iCiAgIGhlaWdodD0iMS4yMTkxNjE5bW0iCiAgIHZpZXdCb3g9IjAgMCAzLjczMjQ5OTggMS4yMTkxNjE5IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczNzI4IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPVERUX3BvbGlnb25fMTAwMC5zdmciCiAgIHhtbG5zOmlua3NjYXBlPSJodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy9uYW1lc3BhY2VzL2lua3NjYXBlIgogICB4bWxuczpzb2RpcG9kaT0iaHR0cDovL3NvZGlwb2RpLnNvdXJjZWZvcmdlLm5ldC9EVEQvc29kaXBvZGktMC5kdGQiCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHNvZGlwb2RpOm5hbWVkdmlldwogICAgIGlkPSJuYW1lZHZpZXczNzMwIgogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBib3JkZXJvcGFjaXR5PSIxLjAiCiAgICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VjaGVja2VyYm9hcmQ9IjAiCiAgICAgaW5rc2NhcGU6ZG9jdW1lbnQtdW5pdHM9Im1tIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpbmtzY2FwZTp6b29tPSI0Ni4yOTU4NDgiCiAgICAgaW5rc2NhcGU6Y3g9IjcuNzk3Njc1NSIKICAgICBpbmtzY2FwZTpjeT0iLTAuMzU2NDAzNDUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzgwOSIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzcyNSI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzgwMyI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzgwMSIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwNi4yNTQ1NCwtMjExLjE5OTEyKSI+CiAgICA8ZwogICAgICAgaWQ9ImczNzk5IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzgwMykiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3Ni43Mjg3MDksMzIyLjI5NDM5KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwNSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcyLjQsMzExLjgpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgMCwwLjcyMDAzMTU3IC0wLjI5OTkyNzEzLDEuNDQwMDYzMSAtMC44MTU2NDIyOSwxLjk2Mzc3MDIgLTEuMDg3NzkwNywyLjI0MDEzNiAtMS40MjAwMzE2LDIuNDYxODI5NyAtMS44LDIuNiAtMi45LDMgLTQuMiwyLjcgLTQuOSwxLjgiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjY4MDMxNSIKCQkgICBzdHJva2UtbGluZWNhcD0icm91bmQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKICAgICAgICAgICBpZD0icGF0aDM4MDciCiAgICAgICAgICAgc29kaXBvZGk6bm9kZXR5cGVzPSJjc3NjIiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwOSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc3LjQsMzEzLjYpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTAuOCwwLjkgLTIsMS4yIC0zLjIsMC44IC00LjMsMC40IC01LC0wLjcgLTUsLTEuOCIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNjgwMzE1IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzgxMSIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="0" k="outline_width" />
-              <prop v="3x:5000,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="" k="parameters" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="2.625" k="size" />
-              <prop v="3x:5000,0,0,0.03,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="5" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{4b40966a-955b-4004-bef0-b6337fd4a527}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="CentroidFill" pass="0" enabled="1">
+        <layer class="CentroidFill" pass="0" id="{282f21ba-3518-4036-8947-ebf3d1081003}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="clip_on_current_part_only" type="QString" value="0" />
-            <Option name="clip_points" type="QString" value="0" />
-            <Option name="point_on_all_parts" type="QString" value="1" />
-            <Option name="point_on_surface" type="QString" value="1" />
+            <Option type="QString" value="0" name="clip_on_current_part_only"/>
+            <Option type="QString" value="0" name="clip_points"/>
+            <Option type="QString" value="1" name="point_on_all_parts"/>
+            <Option type="QString" value="1" name="point_on_surface"/>
           </Option>
-          <prop v="0" k="clip_on_current_part_only" />
-          <prop v="0" k="clip_points" />
-          <prop v="1" k="point_on_all_parts" />
-          <prop v="1" k="point_on_surface" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@5@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@5@1" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SvgMarker" pass="0" enabled="1">
+            <layer class="SvgMarker" pass="0" id="{9046abd6-09cc-4e5e-9929-7704d4a1fbd3}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="color" type="QString" value="255,0,0,255" />
-                <Option name="fixedAspectRatio" type="QString" value="0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="name" type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMi45OTg2MTFtbSIKICAgaGVpZ2h0PSIzLjIzODYxMW1tIgogICB2aWV3Qm94PSIwIDAgMi45OTg2MTEgMy4yMzg2MTEiCiAgIHZlcnNpb249IjEuMSIKICAgaWQ9InN2ZzM4NDUiCiAgIGlua3NjYXBlOnZlcnNpb249IjEuMSAoYzY4ZTIyYzM4NywgMjAyMS0wNS0yMykiCiAgIHNvZGlwb2RpOmRvY25hbWU9Ik9URFAuc3ZnIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpZD0ibmFtZWR2aWV3Mzg0NyIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMS4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAuMCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSIwIgogICAgIGlua3NjYXBlOmRvY3VtZW50LXVuaXRzPSJtbSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgaW5rc2NhcGU6em9vbT0iNDUuMjU0ODM0IgogICAgIGlua3NjYXBlOmN4PSIyLjEyMTMyMDMiCiAgICAgaW5rc2NhcGU6Y3k9IjUuMjAzODY0IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMDAxIgogICAgIGlua3NjYXBlOndpbmRvdy14PSIxMzQxIgogICAgIGlua3NjYXBlOndpbmRvdy15PSIxMDMyIgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0iZzM5MTYiIC8+CiAgPGRlZnMKICAgICBpZD0iZGVmczM4NDIiPgogICAgPGNsaXBQYXRoCiAgICAgICBjbGlwUGF0aFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIKICAgICAgIGlkPSJjbGlwUGF0aDM5MjAiPgogICAgICA8cGF0aAogICAgICAgICBkPSJtIDMzMy4wNzcsMjc0Ljg2NyBoIDEyNS44NDYgdiA2Mi4yNjYgSCAzMzMuMDc3IHYgLTYyLjI2NiIKICAgICAgICAgY2xpcC1ydWxlPSJldmVub2RkIgogICAgICAgICBpZD0icGF0aDM5MTgiIC8+CiAgICA8L2NsaXBQYXRoPgogIDwvZGVmcz4KICA8ZwogICAgIGlua3NjYXBlOmxhYmVsPSJXYXJzdHdhIDEiCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpZD0ibGF5ZXIxIgogICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMDEuNDk5NDYsLTIxMC41MjM1NSkiPgogICAgPGcKICAgICAgIGlkPSJnMzkxNiIKICAgICAgIGNsaXAtcGF0aD0idXJsKCNjbGlwUGF0aDM5MjApIgogICAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMC4zNTI3Nzc3NywwLDAsLTAuMzUyNzc3NzcsNzMuMjI5NDY2LDMyMC4xODEwNSkiPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MjIiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2My42LDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgSCA4LjUiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjY4MDMxNSIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkyNCIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MjYiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM3MCwzMDIpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIFYgNi4yIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MjgiIC8+CiAgICAgIDwvZz4KICAgICAgPGcKICAgICAgICAgaWQ9ImczOTMwIgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNjUuNywzMDIpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIFYgNi4yIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MzIiIC8+CiAgICAgIDwvZz4KICAgICAgPGcKICAgICAgICAgaWQ9ImczOTM0IgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNjUuNywzMDguMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgQyAtMC4xLDEuMiAwLjksMi4zIDIuMiwyLjMgMy40LDIuMyA0LjQsMS4yIDQuMywwIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MzYiIC8+CiAgICAgIDwvZz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPgo=" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_width" type="QString" value="0" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="parameters" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="1.49931" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="255,0,0,255,rgb:1,0,0,1" name="color"/>
+                <Option type="QString" value="0" name="fixedAspectRatio"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMi45OTg2MTFtbSIKICAgaGVpZ2h0PSIzLjIzODYxMW1tIgogICB2aWV3Qm94PSIwIDAgMi45OTg2MTEgMy4yMzg2MTEiCiAgIHZlcnNpb249IjEuMSIKICAgaWQ9InN2ZzM4NDUiCiAgIGlua3NjYXBlOnZlcnNpb249IjEuMSAoYzY4ZTIyYzM4NywgMjAyMS0wNS0yMykiCiAgIHNvZGlwb2RpOmRvY25hbWU9Ik9URFAuc3ZnIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpZD0ibmFtZWR2aWV3Mzg0NyIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMS4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAuMCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSIwIgogICAgIGlua3NjYXBlOmRvY3VtZW50LXVuaXRzPSJtbSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgaW5rc2NhcGU6em9vbT0iNDUuMjU0ODM0IgogICAgIGlua3NjYXBlOmN4PSIyLjEyMTMyMDMiCiAgICAgaW5rc2NhcGU6Y3k9IjUuMjAzODY0IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMDAxIgogICAgIGlua3NjYXBlOndpbmRvdy14PSIxMzQxIgogICAgIGlua3NjYXBlOndpbmRvdy15PSIxMDMyIgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0iZzM5MTYiIC8+CiAgPGRlZnMKICAgICBpZD0iZGVmczM4NDIiPgogICAgPGNsaXBQYXRoCiAgICAgICBjbGlwUGF0aFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIKICAgICAgIGlkPSJjbGlwUGF0aDM5MjAiPgogICAgICA8cGF0aAogICAgICAgICBkPSJtIDMzMy4wNzcsMjc0Ljg2NyBoIDEyNS44NDYgdiA2Mi4yNjYgSCAzMzMuMDc3IHYgLTYyLjI2NiIKICAgICAgICAgY2xpcC1ydWxlPSJldmVub2RkIgogICAgICAgICBpZD0icGF0aDM5MTgiIC8+CiAgICA8L2NsaXBQYXRoPgogIDwvZGVmcz4KICA8ZwogICAgIGlua3NjYXBlOmxhYmVsPSJXYXJzdHdhIDEiCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpZD0ibGF5ZXIxIgogICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMDEuNDk5NDYsLTIxMC41MjM1NSkiPgogICAgPGcKICAgICAgIGlkPSJnMzkxNiIKICAgICAgIGNsaXAtcGF0aD0idXJsKCNjbGlwUGF0aDM5MjApIgogICAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMC4zNTI3Nzc3NywwLDAsLTAuMzUyNzc3NzcsNzMuMjI5NDY2LDMyMC4xODEwNSkiPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MjIiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2My42LDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgSCA4LjUiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjY4MDMxNSIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkyNCIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MjYiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM3MCwzMDIpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIFYgNi4yIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MjgiIC8+CiAgICAgIDwvZz4KICAgICAgPGcKICAgICAgICAgaWQ9ImczOTMwIgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNjUuNywzMDIpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIFYgNi4yIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MzIiIC8+CiAgICAgIDwvZz4KICAgICAgPGcKICAgICAgICAgaWQ9ImczOTM0IgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNjUuNywzMDguMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgQyAtMC4xLDEuMiAwLjksMi4zIDIuMiwyLjMgMy40LDIuMyA0LjQsMS4yIDQuMywwIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MzYiIC8+CiAgICAgIDwvZz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPgo=" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option name="parameters"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="1.49931" name="size"/>
+                <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="255,0,0,255" k="color" />
-              <prop v="0" k="fixedAspectRatio" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMi45OTg2MTFtbSIKICAgaGVpZ2h0PSIzLjIzODYxMW1tIgogICB2aWV3Qm94PSIwIDAgMi45OTg2MTEgMy4yMzg2MTEiCiAgIHZlcnNpb249IjEuMSIKICAgaWQ9InN2ZzM4NDUiCiAgIGlua3NjYXBlOnZlcnNpb249IjEuMSAoYzY4ZTIyYzM4NywgMjAyMS0wNS0yMykiCiAgIHNvZGlwb2RpOmRvY25hbWU9Ik9URFAuc3ZnIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpZD0ibmFtZWR2aWV3Mzg0NyIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMS4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAuMCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSIwIgogICAgIGlua3NjYXBlOmRvY3VtZW50LXVuaXRzPSJtbSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgaW5rc2NhcGU6em9vbT0iNDUuMjU0ODM0IgogICAgIGlua3NjYXBlOmN4PSIyLjEyMTMyMDMiCiAgICAgaW5rc2NhcGU6Y3k9IjUuMjAzODY0IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMDAxIgogICAgIGlua3NjYXBlOndpbmRvdy14PSIxMzQxIgogICAgIGlua3NjYXBlOndpbmRvdy15PSIxMDMyIgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjEiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0iZzM5MTYiIC8+CiAgPGRlZnMKICAgICBpZD0iZGVmczM4NDIiPgogICAgPGNsaXBQYXRoCiAgICAgICBjbGlwUGF0aFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIKICAgICAgIGlkPSJjbGlwUGF0aDM5MjAiPgogICAgICA8cGF0aAogICAgICAgICBkPSJtIDMzMy4wNzcsMjc0Ljg2NyBoIDEyNS44NDYgdiA2Mi4yNjYgSCAzMzMuMDc3IHYgLTYyLjI2NiIKICAgICAgICAgY2xpcC1ydWxlPSJldmVub2RkIgogICAgICAgICBpZD0icGF0aDM5MTgiIC8+CiAgICA8L2NsaXBQYXRoPgogIDwvZGVmcz4KICA8ZwogICAgIGlua3NjYXBlOmxhYmVsPSJXYXJzdHdhIDEiCiAgICAgaW5rc2NhcGU6Z3JvdXBtb2RlPSJsYXllciIKICAgICBpZD0ibGF5ZXIxIgogICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMDEuNDk5NDYsLTIxMC41MjM1NSkiPgogICAgPGcKICAgICAgIGlkPSJnMzkxNiIKICAgICAgIGNsaXAtcGF0aD0idXJsKCNjbGlwUGF0aDM5MjApIgogICAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMC4zNTI3Nzc3NywwLDAsLTAuMzUyNzc3NzcsNzMuMjI5NDY2LDMyMC4xODEwNSkiPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MjIiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2My42LDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgSCA4LjUiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjY4MDMxNSIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkyNCIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MjYiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM3MCwzMDIpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIFYgNi4yIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MjgiIC8+CiAgICAgIDwvZz4KICAgICAgPGcKICAgICAgICAgaWQ9ImczOTMwIgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNjUuNywzMDIpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIFYgNi4yIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MzIiIC8+CiAgICAgIDwvZz4KICAgICAgPGcKICAgICAgICAgaWQ9ImczOTM0IgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNjUuNywzMDguMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgQyAtMC4xLDEuMiAwLjksMi4zIDIuMiwyLjMgMy40LDIuMyA0LjQsMS4yIDQuMywwIgogICAgICAgICAgIGZpbGw9Im5vbmUiCgkJICAgc3Ryb2tlPSJwYXJhbShvdXRsaW5lKSAjMDAwIgoJCSAgIHN0cm9rZS13aWR0aD0iMC42ODAzMTUiCgkJICAgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKCQkgICBpZD0icGF0aDM5MzYiIC8+CiAgICAgIDwvZz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPgo=" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="0" k="outline_width" />
-              <prop v="3x:5000,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="" k="parameters" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="1.49931" k="size" />
-              <prop v="3x:5000,0,0,0.03,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="6" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{31e7647e-8bbb-40dc-965e-510f13d6c945}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="3;1.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.35" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="3;1.5" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.35" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="1" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="3;1.5" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.35" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="7" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{f0861d3d-8999-4024-9beb-35ce148e4966}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="8" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{e4a99dfd-0194-497d-ab04-428304e1dff8}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="9" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="9" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{a21b01a9-7e65-49e2-89d4-6dbb2e5ab9b5}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:5000,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol force_rhr="0" is_animated="0" type="fill" name="" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" id="{27fc79de-f641-48d6-b9fd-63851f0e00bd}" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{590c8450-c7ec-486f-a6fc-b2fe3bfca01e}">
       <rule description="wieża ciśnień" filter="rodzajBudowli = 'c'" key="{a51b4afa-9635-4bb9-88b3-79d64a54956e}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'cis'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'cis'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{4294646c-0c76-4d6f-ad6b-183522cadec6}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="wieża przeciwpożarowa" filter="rodzajBudowli = 'z'" key="{453adea6-54d8-4731-8128-e1555768c623}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'poż'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'poż'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{a9e0cf39-3b64-4303-9449-611112a1d860}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="wieża szybu kopalnianego" filter="rodzajBudowli = 's'" key="{8dd14b26-2ced-49f4-a0d9-194a8d9a9455}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'sk'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'sk'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{808949c3-6d8c-4279-be48-864f19ceb3ea}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="wieża widokowa" filter="rodzajBudowli = 'w'" key="{beb74961-a35a-468f-9969-34f4ada31635}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'wid'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'wid'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{04dc64a3-013c-41a3-994e-0550e9b5248d}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="zbiornik, silos" filter="rodzajBudowli = 'b'" key="{9dcec905-2858-45b4-8e07-dc89c398270a}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'zb'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'zb'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{d044fd12-6115-43c7-93bf-dd07d48728ca}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="śmietnik" filter="rodzajBudowli = 'm'" key="{252a3d96-a750-4b5d-9738-40f3682436ae}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'sm'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'sm'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{ba25c72a-5d93-47a5-b13b-71a6a425bffd}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="ruina zabytkowa" filter="rodzajBudowli = 'r'" key="{bd663487-09c8-4127-8fe2-c6da9e1b8a8d}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'zab'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'zab'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{ed769b39-7c8f-4e79-98b7-986be50e6b71}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="inna budowla" filter="rodzajBudowli = 'i'" key="{53d52960-78cf-4ccb-963f-c8969ae3f8f5}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'ib'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.5625" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'ib'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="0" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="PreventOverlap" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{e7166fdb-0ca0-4aad-ab7b-c29ed8ac01b0}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="&quot;fid&quot;" />
-      </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/1000/polygon/OT_Komunikacja.qml
+++ b/stylization/1000/polygon/OT_Komunikacja.qml
@@ -1,2573 +1,1994 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{6669a1a9-987c-4a77-b897-7d88a06239dd}">
-      <rule filter="rodzajObiektu = 'j'" symbol="0" label="jezdnia" key="{676c2901-c1b5-4812-be23-8a349a317223}" />
-      <rule filter="rodzajObiektu = 'c'" symbol="1" label="chodnik" key="{b2abe3b4-6246-4ca6-ba2a-57716e8794eb}" />
-      <rule filter="rodzajObiektu = 'g'" symbol="2" label="droga dla rowerów" key="{bd775299-ca07-41d8-baa9-52d4e93663b3}" />
-      <rule filter="rodzajObiektu = 'u'" symbol="3" label="obszar utwardzony" key="{3621eae1-1c3f-45d0-b9ed-8e24f36d3cf1}" />
-      <rule filter="rodzajObiektu = 'r'" symbol="4" label="rów przydrożny" key="{5321ae88-caf9-4ddc-ad8f-ca585154f399}" />
-      <rule filter="rodzajObiektu = 'z'" symbol="5" label="przepust" key="{9abf2839-2735-41e2-8714-87165299506b}" />
-      <rule filter="rodzajObiektu = 's' " symbol="6" label="schody w ciągu komunikacyjnym" key="{e25415e8-ca5b-4802-b9e7-c18b74f1aca1}" />
-      <rule filter="rodzajObiektu = 'm'" symbol="7" label="most" key="{b73dc8b4-ff2c-452c-bc83-7109e6529ae0}" />
-      <rule filter="rodzajObiektu = 'w'" symbol="8" label="wiadukt" key="{05d617ae-73fa-4d4c-b5aa-ce3e63d8abd6}" />
-      <rule filter="rodzajObiektu = 'e'" symbol="9" label="estakada" key="{9ad9af7a-0a03-4ee6-8493-e8fd4a31d27d}" />
-      <rule filter="rodzajObiektu = 'n'" symbol="10" label="peron" key="{09388348-12c0-4f98-b7c4-e3f656ee3dc0}" />
-      <rule filter="rodzajObiektu = 'a'" symbol="11" label="rampa" key="{81a3fe45-9d13-44f0-88b4-5adafcc4788d}" />
-      <rule filter="rodzajObiektu = 'i'" symbol="12" label="inny obiekt komunikacyjny" key="{224e0e5f-d3c3-4033-addd-072e911a0e77}" />
-      <rule filter="ELSE" symbol="13" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}" />
+      <rule symbol="0" key="{676c2901-c1b5-4812-be23-8a349a317223}" label="jezdnia" filter="rodzajObiektu = 'j'"/>
+      <rule symbol="1" key="{b2abe3b4-6246-4ca6-ba2a-57716e8794eb}" label="chodnik" filter="rodzajObiektu = 'c'"/>
+      <rule symbol="2" key="{bd775299-ca07-41d8-baa9-52d4e93663b3}" label="droga dla rowerów" filter="rodzajObiektu = 'g'"/>
+      <rule symbol="3" key="{3621eae1-1c3f-45d0-b9ed-8e24f36d3cf1}" label="obszar utwardzony" filter="rodzajObiektu = 'u'"/>
+      <rule symbol="4" key="{5321ae88-caf9-4ddc-ad8f-ca585154f399}" label="rów przydrożny" filter="rodzajObiektu = 'r'"/>
+      <rule symbol="5" key="{9abf2839-2735-41e2-8714-87165299506b}" label="przepust" filter="rodzajObiektu = 'z'"/>
+      <rule symbol="6" key="{e25415e8-ca5b-4802-b9e7-c18b74f1aca1}" label="schody w ciągu komunikacyjnym" filter="rodzajObiektu = 's' "/>
+      <rule symbol="7" key="{b73dc8b4-ff2c-452c-bc83-7109e6529ae0}" label="most" filter="rodzajObiektu = 'm'"/>
+      <rule symbol="8" key="{05d617ae-73fa-4d4c-b5aa-ce3e63d8abd6}" label="wiadukt" filter="rodzajObiektu = 'w'"/>
+      <rule symbol="9" key="{9ad9af7a-0a03-4ee6-8493-e8fd4a31d27d}" label="estakada" filter="rodzajObiektu = 'e'"/>
+      <rule symbol="10" key="{09388348-12c0-4f98-b7c4-e3f656ee3dc0}" label="peron" filter="rodzajObiektu = 'n'"/>
+      <rule symbol="11" key="{81a3fe45-9d13-44f0-88b4-5adafcc4788d}" label="rampa" filter="rodzajObiektu = 'a'"/>
+      <rule symbol="12" key="{224e0e5f-d3c3-4033-addd-072e911a0e77}" label="inny obiekt komunikacyjny" filter="rodzajObiektu = 'i'"/>
+      <rule symbol="13" key="{427914c2-1048-4e08-b88d-475ca325312a}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{bef27c7c-98d1-46a5-996b-b7bd23e6b4d2}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="2.25;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="2.25;0.75" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="2.25;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{1cf2e2b4-b3a8-4719-99ef-de5c9882cdc0}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1.5;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1.5;0.75" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1.5;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="10" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="10" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{4b9615a6-e8d1-4b43-bfeb-5e413fbb56ce}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="11" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="11" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{e56cdee9-26af-4175-9ecc-c961fedbb42e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="12" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="12" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{6a45e624-2ecd-487f-a28d-f08e02be2d4c}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="13" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="13" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{c40aa338-9dbc-42bd-b0f2-374ee6b1062d}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.1" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.1" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:5000,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.1" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{82235987-d499-45d2-b5b3-d60adf071346}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1.5;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1.5;0.75" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1.5;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{db3742b4-c946-4986-92b7-b2d930b1031c}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="2.25;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="2.25;0.75" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="2.25;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{b41c6ee4-9b8b-49a3-a16b-c75da97fcac5}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{f3de526d-e9c3-4861-bbb3-5efcac814077}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.25" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.5;0.5" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{ecf9ca2a-71ca-4a19-be7c-b37d4d37c3ca}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value=" geom_from_wkt(  &quot;obliczona_geometria_1000&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_1000'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v=" geom_from_wkt(  &quot;obliczona_geometria_1000&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@6@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{f295b39e-cce4-4362-a59b-19a883a03ec1}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{abfc23a7-8458-41a1-a4e4-97a9cc9f8c5c}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{c404bc46-f028-48ed-853b-713539212782}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="color" type="QString" value="255,255,255,0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,0,0,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.25" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="color" value="255,255,255,0,rgb:1,1,1,0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.25" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:5000,0,0,0.03,0,0" k="border_width_map_unit_scale" />
-          <prop v="255,255,255,0" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,0,0,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.25" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{23c11f38-943c-40be-93d5-a44af7ac3bbe}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.25" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="9" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="9" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{85df16a8-0f1e-4aaf-91fc-46c6e7992f4f}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.25" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{71c0f939-12e2-4a4d-9e76-d71b2b78e738}">
-      <rule description="jezdnia" filter="rodzajObiektu = 'j'" key="{85f53cc6-e798-4345-85c5-6fed52e65315}">
+      <rule key="{85f53cc6-e798-4345-85c5-6fed52e65315}" description="jezdnia" filter="rodzajObiektu = 'j'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'j.' + try(&quot;rodzajNawierzchni&quot;)" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'j.' + try(&quot;rodzajNawierzchni&quot;)" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{f2d21ae3-cbeb-4af9-bad4-5ed9fbc7b30b}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="chodnik" filter="rodzajObiektu = 'c'" key="{3cda7d43-a9ae-4e7f-84f5-eafaa62a1af6}">
+      <rule key="{3cda7d43-a9ae-4e7f-84f5-eafaa62a1af6}" description="chodnik" filter="rodzajObiektu = 'c'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'ch.' + try(&quot;rodzajNawierzchni&quot;)" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'ch.' + try(&quot;rodzajNawierzchni&quot;)" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{83cf8a32-34ef-4cdf-85b1-d146d6d61ee5}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="droga dla rowerów" filter="rodzajObiektu = 'g'" key="{7b89aeb4-51be-4a59-a16d-1b4c361ecbdb}">
+      <rule key="{7b89aeb4-51be-4a59-a16d-1b4c361ecbdb}" description="droga dla rowerów" filter="rodzajObiektu = 'g'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'r'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'r'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{6e699910-7970-40c8-9028-2a24612887c0}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="obszar utwardzony" filter="rodzajObiektu = 'u'" key="{d3b7e01d-0c75-4f06-9c93-bff4734c083d}">
+      <rule key="{d3b7e01d-0c75-4f06-9c93-bff4734c083d}" description="obszar utwardzony" filter="rodzajObiektu = 'u'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="try(&quot;rodzajNawierzchni&quot;)+'.'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="try(&quot;rodzajNawierzchni&quot;)+'.'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{5c43b270-a6a4-4dfe-ab04-09d96d6716ac}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="rów przydrożny" filter="rodzajObiektu = 'r'" key="{942b5bcf-93c1-4e91-bebd-155c14207b8c}">
+      <rule key="{942b5bcf-93c1-4e91-bebd-155c14207b8c}" description="rów przydrożny" filter="rodzajObiektu = 'r'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'w.'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'w.'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{9da9f9c5-f6cb-46e2-923b-579604596c75}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="peron" filter="rodzajObiektu = 'n'" key="{de937b0d-0fb2-4934-b41d-23af80d49aa4}">
+      <rule key="{de937b0d-0fb2-4934-b41d-23af80d49aa4}" description="peron" filter="rodzajObiektu = 'n'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'per'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'per'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{e9edb832-825f-43d9-b7ba-2087eb5a08ef}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="rampa" filter="rodzajObiektu = 'a'" key="{dc3747ad-bf51-4945-8239-718562537c62}">
+      <rule key="{dc3747ad-bf51-4945-8239-718562537c62}" description="rampa" filter="rodzajObiektu = 'a'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'rmp'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'rmp'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{596b6fca-eb9b-4190-a6f9-ccc549916aba}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="inny obiekt komunikacyjny" filter="rodzajObiektu = 'i'" key="{edbada72-9a70-4eb3-9cf8-c34b34d53921}">
+      <rule key="{edbada72-9a70-4eb3-9cf8-c34b34d53921}" description="inny obiekt komunikacyjny" filter="rodzajObiektu = 'i'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'ok'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'ok'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{fdbdcd21-d87d-4ff8-a5f0-161775c7a790}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/1000/polygon/OT_ObiektTrwaleZwiazanyZBudynkami.qml
+++ b/stylization/1000/polygon/OT_ObiektTrwaleZwiazanyZBudynkami.qml
@@ -1,1601 +1,1183 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{1aed1771-116e-4ba7-a492-cd5f1573b91b}">
-      <rule filter="rodzajObiektu = 't'" symbol="0" label="taras" key="{803b29a7-0c6a-401d-a3b9-6f5c5931288c}" />
-      <rule filter="rodzajObiektu = 'w'" symbol="1" label="weranda, ganek" key="{1e4318cd-a9cc-4fb4-89d5-d1ace62f0e05}" />
-      <rule filter="rodzajObiektu = 'i'" symbol="2" label="wiatrołap" key="{805755b1-0b08-48ed-8f89-32e251e5e287}" />
-      <rule filter="rodzajObiektu = 's' " symbol="3" label="schody" key="{b646e586-87cb-480c-b2e3-aa07e629729a}" />
-      <rule filter="rodzajObiektu = 'o'" symbol="4" label="podpora związana z budynkiem" key="{9315336e-9352-4f65-a647-a6a44f8b06a3}" />
-      <rule filter="rodzajObiektu = 'r'" symbol="5" label="rampa" key="{a3179843-9e2c-4e33-8fe6-68f95271a0b2}" />
-      <rule filter="rodzajObiektu = 'j'" symbol="6" label="wjazd do podziemia" key="{a29feab3-a9ed-4c13-87ff-df5cb8cd32a2}" />
-      <rule filter="rodzajObiektu = 'd'" symbol="7" label="podjazd dla osób niepełnosprawnych" key="{e40132d5-9fba-4968-97b2-e54f213209d9}" />
-      <rule filter="ELSE" symbol="8" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}" />
+      <rule symbol="0" key="{803b29a7-0c6a-401d-a3b9-6f5c5931288c}" label="taras" filter="rodzajObiektu = 't'"/>
+      <rule symbol="1" key="{1e4318cd-a9cc-4fb4-89d5-d1ace62f0e05}" label="weranda, ganek" filter="rodzajObiektu = 'w'"/>
+      <rule symbol="2" key="{805755b1-0b08-48ed-8f89-32e251e5e287}" label="wiatrołap" filter="rodzajObiektu = 'i'"/>
+      <rule symbol="3" key="{b646e586-87cb-480c-b2e3-aa07e629729a}" label="schody" filter="rodzajObiektu = 's' "/>
+      <rule symbol="4" key="{9315336e-9352-4f65-a647-a6a44f8b06a3}" label="podpora związana z budynkiem" filter="rodzajObiektu = 'o'"/>
+      <rule symbol="5" key="{a3179843-9e2c-4e33-8fe6-68f95271a0b2}" label="rampa" filter="rodzajObiektu = 'r'"/>
+      <rule symbol="6" key="{a29feab3-a9ed-4c13-87ff-df5cb8cd32a2}" label="wjazd do podziemia" filter="rodzajObiektu = 'j'"/>
+      <rule symbol="7" key="{e40132d5-9fba-4968-97b2-e54f213209d9}" label="podjazd dla osób niepełnosprawnych" filter="rodzajObiektu = 'd'"/>
+      <rule symbol="8" key="{427914c2-1048-4e08-b88d-475ca325312a}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{dda3053f-7449-4d5e-b051-ce9197de80e3}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{6865ed27-aec1-48e6-9cbb-2d4538d7bf95}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.75" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.75" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.75" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{f8e9d6e5-687c-4ec4-9814-8d744e87614c}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.75;0.75" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.75" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.75;0.75" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.75" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.75;0.75" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.75" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{7097b1ad-3312-403d-aa65-f757e5135a62}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" id="{900a0e12-7b65-4b11-9c4e-923fa94eab1f}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MapUnit" />
-            <Option name="interval" type="QString" value="0.75" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="Interval" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option name="average_angle_length" value="4" type="QString"/>
+            <Option name="average_angle_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="average_angle_unit" value="MapUnit" type="QString"/>
+            <Option name="interval" value="0.75" type="QString"/>
+            <Option name="interval_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="interval_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_along_line" value="0" type="QString"/>
+            <Option name="offset_along_line_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="offset_along_line_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="place_on_every_part" value="true" type="bool"/>
+            <Option name="placements" value="Interval" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="rotate" value="1" type="QString"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MapUnit" k="average_angle_unit" />
-          <prop v="0.75" k="interval" />
-          <prop v="3x:5000,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:5000,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="Interval" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@2@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{40255fd5-cc0c-4060-8da9-e621736cffb3}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.18" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.18" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.18" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.18" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.18" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.18" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{5f7a446a-a4eb-4a99-8393-053bcbc83d2f}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{266e4b89-6bf2-4073-85ac-c8be97c3e426}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_1000&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_1000'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_1000&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@3@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@3@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{ffa92759-653f-46f7-858a-40423c041830}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{895377b2-3123-476b-9e48-1738fdbb6130}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{2dc4a35e-dfae-4158-b573-8a724c27fd95}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c96bde20-7bc4-45cd-b6eb-aa3b96baeb87}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{d7cfa539-5c83-43b8-bccb-0e8aa249233f}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="PointPatternFill" pass="0" enabled="1">
+        <layer class="PointPatternFill" id="{fc3ab111-4ffb-49b2-af50-35069087d2b0}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="angle" type="double" value="0" />
-            <Option name="clip_mode" type="QString" value="shape" />
-            <Option name="coordinate_reference" type="QString" value="feature" />
-            <Option name="displacement_x" type="QString" value="0.75" />
-            <Option name="displacement_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="displacement_x_unit" type="QString" value="MapUnit" />
-            <Option name="displacement_y" type="QString" value="0" />
-            <Option name="displacement_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="displacement_y_unit" type="QString" value="MapUnit" />
-            <Option name="distance_x" type="QString" value="1.5" />
-            <Option name="distance_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="distance_x_unit" type="QString" value="MapUnit" />
-            <Option name="distance_y" type="QString" value="1.5" />
-            <Option name="distance_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="distance_y_unit" type="QString" value="MapUnit" />
-            <Option name="offset_x" type="QString" value="0" />
-            <Option name="offset_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_x_unit" type="QString" value="MapUnit" />
-            <Option name="offset_y" type="QString" value="0" />
-            <Option name="offset_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_y_unit" type="QString" value="MapUnit" />
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="random_deviation_x" type="QString" value="0" />
-            <Option name="random_deviation_x_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="random_deviation_x_unit" type="QString" value="MM" />
-            <Option name="random_deviation_y" type="QString" value="0" />
-            <Option name="random_deviation_y_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="random_deviation_y_unit" type="QString" value="MM" />
-            <Option name="seed" type="QString" value="506757113" />
+            <Option name="angle" value="0" type="double"/>
+            <Option name="clip_mode" value="shape" type="QString"/>
+            <Option name="coordinate_reference" value="feature" type="QString"/>
+            <Option name="displacement_x" value="0.75" type="QString"/>
+            <Option name="displacement_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_x_unit" value="MapUnit" type="QString"/>
+            <Option name="displacement_y" value="0" type="QString"/>
+            <Option name="displacement_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_y_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_x" value="1.5" type="QString"/>
+            <Option name="distance_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_x_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_y" value="1.5" type="QString"/>
+            <Option name="distance_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_y_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_x" value="0" type="QString"/>
+            <Option name="offset_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_x_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_y" value="0" type="QString"/>
+            <Option name="offset_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_y_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="random_deviation_x" value="0" type="QString"/>
+            <Option name="random_deviation_x_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_x_unit" value="MM" type="QString"/>
+            <Option name="random_deviation_y" value="0" type="QString"/>
+            <Option name="random_deviation_y_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_y_unit" value="MM" type="QString"/>
+            <Option name="seed" value="506757113" type="QString"/>
           </Option>
-          <prop v="0" k="angle" />
-          <prop v="shape" k="clip_mode" />
-          <prop v="feature" k="coordinate_reference" />
-          <prop v="0.75" k="displacement_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="displacement_x_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_x_unit" />
-          <prop v="0" k="displacement_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="displacement_y_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_y_unit" />
-          <prop v="1.5" k="distance_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="distance_x_map_unit_scale" />
-          <prop v="MapUnit" k="distance_x_unit" />
-          <prop v="1.5" k="distance_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="distance_y_map_unit_scale" />
-          <prop v="MapUnit" k="distance_y_unit" />
-          <prop v="0" k="offset_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_x_map_unit_scale" />
-          <prop v="MapUnit" k="offset_x_unit" />
-          <prop v="0" k="offset_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_y_map_unit_scale" />
-          <prop v="MapUnit" k="offset_y_unit" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="0" k="random_deviation_x" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="random_deviation_x_map_unit_scale" />
-          <prop v="MM" k="random_deviation_x_unit" />
-          <prop v="0" k="random_deviation_y" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="random_deviation_y_map_unit_scale" />
-          <prop v="MM" k="random_deviation_y_unit" />
-          <prop v="506757113" k="seed" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@6@1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{36007492-68c2-47dd-ad5c-a5a28746d4bf}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.18" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.18" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.18" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.18" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.18" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.18" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{06f7e001-dc51-43a1-b279-90279535a3c7}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{301ce9e3-f54c-491e-9723-5fc4f3e90611}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.1" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.1" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:5000,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.1" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{ee3797dd-be6e-48cf-9175-77bd88950b2f}">
-      <rule description="rampa" filter="rodzajObiektu = 'r'" key="{2f60b2dc-3f29-410a-bb2d-aa475c18e944}">
+      <rule key="{2f60b2dc-3f29-410a-bb2d-aa475c18e944}" description="rampa" filter="rodzajObiektu = 'r'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'rmp'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'rmp'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="232,113,141,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="232,113,141,255,rgb:0.90980392156862744,0.44313725490196076,0.55294117647058827,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="232,113,141,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="0" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="PreventOverlap" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="0" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{2383847b-1ad6-4c29-a615-25432d854975}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="podjazd dla osób niepełnosprawnych" filter="rodzajObiektu = 'd'" key="{41c0bfaf-9c5f-4685-a59b-160d4f8fd85d}">
+      <rule key="{41c0bfaf-9c5f-4685-a59b-160d4f8fd85d}" description="podjazd dla osób niepełnosprawnych" filter="rodzajObiektu = 'd'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'n'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'n'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="255,158,23,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="255,158,23,255,rgb:1,0.61960784313725492,0.09019607843137255,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="255,158,23,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="0" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="PreventOverlap" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="0" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{624e0e79-b80d-4e5e-a6e8-cbfd0266a5a0}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/1000/polygon/OT_Skarpa.qml
+++ b/stylization/1000/polygon/OT_Skarpa.qml
@@ -1,416 +1,328 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="0"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="0">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{fa52eebb-7997-4077-af46-9e415d571107}">
-      <rule filter="rodzajSkarpy = 'u'" symbol="0" label="skarpa umocniona" key="{15922814-7eea-4bdf-b667-7e6b1b53e98f}" />
-      <rule filter="rodzajSkarpy = 'k'" symbol="1" label="skarpa nieumocniona" key="{253c47bf-fdfd-4a5c-ae8e-e1c919c3007a}" />
-      <rule filter="ELSE" symbol="2" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}" />
+      <rule symbol="0" key="{15922814-7eea-4bdf-b667-7e6b1b53e98f}" label="skarpa umocniona" filter="rodzajSkarpy = 'u'"/>
+      <rule symbol="1" key="{253c47bf-fdfd-4a5c-ae8e-e1c919c3007a}" label="skarpa nieumocniona" filter="rodzajSkarpy = 'k'"/>
+      <rule symbol="2" key="{427914c2-1048-4e08-b88d-475ca325312a}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{1862fa99-f534-4695-ade3-daf035bba424}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@0@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{fcd14c8b-902f-443b-becb-da7de64a49a5}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{e038961b-6d18-4690-a2c9-e60e01d5382e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{a15a6362-c149-4be7-a75d-c35f7bbea070}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@1@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@1@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{9e41b22c-974b-49d7-9f0c-ff07b31459eb}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c9bd17d0-2ee0-40f5-912f-0546b7e5392e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="2;1" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="2;1" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="2;1" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{5a551893-ecb8-4210-b9b0-01086b20c95e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.1" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.1" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:5000,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.1" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/1000/polygon/OT_Wody.qml
+++ b/stylization/1000/polygon/OT_Wody.qml
@@ -1,2187 +1,1673 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{71582cbe-1e93-488f-89e9-bf554833455f}">
-      <rule filter="rodzajObiektu = 'p'" symbol="0" label="woda płynąca" key="{abd262f0-2c39-406a-b9b3-df9a46365db8}" />
-      <rule filter="rodzajObiektu = 's'" symbol="1" label="woda stojąca" key="{7c8976f0-1b34-4e10-a7db-d3121faefe42}" />
-      <rule filter="rodzajObiektu = 'w'" symbol="2" label="wal przeciwpowodziowy" key="{fb573704-17ff-455c-9fb6-6ed825192a7c}" />
-      <rule filter="rodzajObiektu = 'm'" symbol="3" label="row melioracyjny" key="{1de5dcbc-2167-44d4-a92c-8b91a6a77764}" />
-      <rule filter="rodzajObiektu = 'j'" symbol="4" label="jaz" key="{989a9418-e9c4-4a38-9efc-7e3493323205}" />
-      <rule filter="rodzajObiektu = 'l'" symbol="5" label="śluza" key="{a45032ba-6bf8-492b-9ae9-73a3bb120dad}" />
-      <rule filter="rodzajObiektu = 'g'" symbol="6" label="grobla" key="{195b312b-41ca-4f6d-aa3b-07ce92e360f7}" />
-      <rule filter="rodzajObiektu = 'z'" symbol="7" label="zapora" key="{66bb1a4e-5b60-45dd-b8c4-ba6330bd611d}" />
-      <rule filter="rodzajObiektu = 't'" symbol="8" label="ostroga" key="{7eea6079-e176-4928-8e4a-f48e7b59f0bd}" />
-      <rule filter="rodzajObiektu = 'o'" symbol="9" label="pomost, molo" key="{9630ff64-f70f-4372-b921-e4b27899b092}" />
-      <rule filter="rodzajObiektu = 'i'" symbol="10" label="inny obiekt" key="{3b13d8b0-dfc3-4c23-9e93-df2c074807db}" />
-      <rule filter="ELSE" symbol="11" label="nieoznaczone" key="{427914c2-1048-4e08-b88d-475ca325312a}" />
+      <rule symbol="0" key="{abd262f0-2c39-406a-b9b3-df9a46365db8}" label="woda płynąca" filter="rodzajObiektu = 'p'"/>
+      <rule symbol="1" key="{7c8976f0-1b34-4e10-a7db-d3121faefe42}" label="woda stojąca" filter="rodzajObiektu = 's'"/>
+      <rule symbol="2" key="{fb573704-17ff-455c-9fb6-6ed825192a7c}" label="wal przeciwpowodziowy" filter="rodzajObiektu = 'w'"/>
+      <rule symbol="3" key="{1de5dcbc-2167-44d4-a92c-8b91a6a77764}" label="row melioracyjny" filter="rodzajObiektu = 'm'"/>
+      <rule symbol="4" key="{989a9418-e9c4-4a38-9efc-7e3493323205}" label="jaz" filter="rodzajObiektu = 'j'"/>
+      <rule symbol="5" key="{a45032ba-6bf8-492b-9ae9-73a3bb120dad}" label="śluza" filter="rodzajObiektu = 'l'"/>
+      <rule symbol="6" key="{195b312b-41ca-4f6d-aa3b-07ce92e360f7}" label="grobla" filter="rodzajObiektu = 'g'"/>
+      <rule symbol="7" key="{66bb1a4e-5b60-45dd-b8c4-ba6330bd611d}" label="zapora" filter="rodzajObiektu = 'z'"/>
+      <rule symbol="8" key="{7eea6079-e176-4928-8e4a-f48e7b59f0bd}" label="ostroga" filter="rodzajObiektu = 't'"/>
+      <rule symbol="9" key="{9630ff64-f70f-4372-b921-e4b27899b092}" label="pomost, molo" filter="rodzajObiektu = 'o'"/>
+      <rule symbol="10" key="{3b13d8b0-dfc3-4c23-9e93-df2c074807db}" label="inny obiekt" filter="rodzajObiektu = 'i'"/>
+      <rule symbol="11" key="{427914c2-1048-4e08-b88d-475ca325312a}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{404ea7a3-69ea-4b45-9392-6e4aeb46a0de}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="89,217,255,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="89,217,255,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{88503cab-992b-463f-b2a8-8f02488983b9}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="89,217,255,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="89,217,255,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="10" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="10" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{74eded63-2595-4667-9f3f-ea5059f483b1}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="11" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="11" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{0df63e44-f6f9-4677-9e56-589f85038cf5}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:5000,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.1" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:5000,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.1" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:5000,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.1" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{db8b44d8-898b-45a4-a658-1089bb507c42}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@2@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{8ca74be5-aa3f-43e1-959e-ffa3b4205a8c}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{95497c95-195e-4c7b-98ec-c1ce1a12548b}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="square" />
-            <Option name="customdash" type="QString" value="2;1" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="bevel" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="2;1" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="square" k="capstyle" />
-          <prop v="2;1" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="bevel" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{f27a8696-b6d5-44df-9437-ccb3cd959979}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.5;0.5" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{3d6aa174-a701-47d0-8296-b3e4950675b6}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.25" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{d85fc614-30f1-4c34-aaf8-789d6806a7fe}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.25" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{1d462736-b93a-468a-8ee1-bba19540d379}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@6@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{785a1e51-78f8-480d-9de5-92a0e64aaf80}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.18" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.18" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.18" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{fbd668ec-6b9b-4c1e-9e7d-fd652e8ac145}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="square" />
-            <Option name="customdash" type="QString" value="2;1" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="bevel" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="2;1" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="square" k="capstyle" />
-          <prop v="2;1" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="bevel" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{d2c3991e-6213-4cc8-be48-09f9d4332446}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.25" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{7a708d99-9bf6-408d-b898-1972cc5b97c4}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="9" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="9" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{432c7c13-3dc8-4fb6-b10c-b918070169ce}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.18" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:5000,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.18" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:5000,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.18" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:5000,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{af9c4301-526e-454e-9555-a9640088757c}">
-      <rule description="woda płynąca" filter="rodzajObiektu = 'p'" key="{5d55618d-08e4-4671-aca3-9a1710c74fa4}">
+      <rule key="{5d55618d-08e4-4671-aca3-9a1710c74fa4}" description="woda płynąca" filter="rodzajObiektu = 'p'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="89,217,255,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="try(&quot;nazwaWlasna&quot;)" fontSize="2.6042000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="try(&quot;nazwaWlasna&quot;)" isExpression="1" fontSize="2.6042000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{f9c3cb94-3a3a-4649-9923-4c62beffc1da}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="woda stojąca" filter="rodzajObiektu = 's'" key="{f8353c8f-4d24-452c-84e0-2df310389dc8}">
+      <rule key="{f8353c8f-4d24-452c-84e0-2df310389dc8}" description="woda stojąca" filter="rodzajObiektu = 's'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="89,217,255,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="case&#10; when&#10;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is not null&#10; then&#10; try( &quot;nazwaWlasna&quot; )&#10; when&#10;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is null&#10; then&#10; 'w.'&#10; end&#10; " fontSize="2.6042000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="case&#xa; when&#xa;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is not null&#xa; then&#xa; try( &quot;nazwaWlasna&quot; )&#xa; when&#xa;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is null&#xa; then&#xa; 'w.'&#xa; end&#xa; " isExpression="1" fontSize="2.6042000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{d8337505-49dc-43eb-bdae-370d1fe6eb25}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="rów melioracyjny" filter="rodzajObiektu = 'm'" key="{b560e996-92dd-45b9-baad-fb2d7b99870f}">
+      <rule key="{b560e996-92dd-45b9-baad-fb2d7b99870f}" description="rów melioracyjny" filter="rodzajObiektu = 'm'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'w.'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'w.'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{b3a2ef98-d235-4d7f-9c6d-885e5a4ac2f6}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="jaz" filter="rodzajObiektu = 'j'" key="{b2bef2ca-9ccc-4b47-b24f-5face1408c18}">
+      <rule key="{b2bef2ca-9ccc-4b47-b24f-5face1408c18}" description="jaz" filter="rodzajObiektu = 'j'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'jaz'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'jaz'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{384f81cf-6257-459e-b341-09b046439fc1}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="śluza" filter="rodzajObiektu = 'l'" key="{ca8d2fef-aa40-4745-ab8e-2a71e205b7f7}">
+      <rule key="{ca8d2fef-aa40-4745-ab8e-2a71e205b7f7}" description="śluza" filter="rodzajObiektu = 'l'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'śl'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'śl'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{7c104b9c-6834-48a1-9b7c-c9ead6a2f9de}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="pomost, molo" filter="rodzajObiektu = 'o'" key="{1d88cd40-cf0a-433a-99db-8b1f1cf49b13}">
+      <rule key="{1d88cd40-cf0a-433a-99db-8b1f1cf49b13}" description="pomost, molo" filter="rodzajObiektu = 'o'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'molo'" fontSize="1.5625" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'molo'" isExpression="1" fontSize="1.5625" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:5000,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{29beacb3-c8b4-42c6-aabc-82648504ddd9}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="&quot;fid&quot;" />
-      </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/500/polygon/EGB_ObiektTrwaleZwiazanyZBudynkiem.qml
+++ b/stylization/500/polygon/EGB_ObiektTrwaleZwiazanyZBudynkiem.qml
@@ -1,1695 +1,1266 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{4402cd2b-a26f-44a1-a5bc-6664c7967240}">
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 't'" symbol="0" label="taras" key="{fa065e21-bd4d-4b32-95d5-1b14a396186a}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'w'" symbol="1" label="weranda, ganek" key="{b11b6b99-f24c-4dac-b2ad-a96f9f2699b1}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'i'" symbol="2" label="wiatrołap" key="{795ad3ec-f7a8-4344-9278-b74b6547559f}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem = 's' " symbol="3" label="schody" key="{6188d76b-a136-4240-9b44-72b1f4a180ce}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'o'" symbol="4" label="podpora" key="{0d857496-54b8-4ece-bc37-2c0a3ad07e4f}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'r'" symbol="5" label="rampa" key="{4f92aea1-46ea-40bd-91e8-1f71bc3cabf3}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'j'" symbol="6" label="wjazd do podziemia" key="{7446eccf-4e2d-4a13-8113-61a5ba239d4c}" />
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'd'" symbol="7" label="podjazd dla osób niepełnosprawnych" key="{89f057ff-ee2b-43fb-b41f-67e5a58b4ef6}" />
-      <rule filter="ELSE" symbol="8" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" />
+      <rule symbol="0" key="{fa065e21-bd4d-4b32-95d5-1b14a396186a}" label="taras" filter="rodzajObiektuZwiazanegoZBudynkiem = 't'"/>
+      <rule symbol="1" key="{b11b6b99-f24c-4dac-b2ad-a96f9f2699b1}" label="weranda, ganek" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'w'"/>
+      <rule symbol="2" key="{795ad3ec-f7a8-4344-9278-b74b6547559f}" label="wiatrołap" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'i'"/>
+      <rule symbol="3" key="{6188d76b-a136-4240-9b44-72b1f4a180ce}" label="schody" filter="rodzajObiektuZwiazanegoZBudynkiem = 's' "/>
+      <rule symbol="4" key="{0d857496-54b8-4ece-bc37-2c0a3ad07e4f}" label="podpora" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'o'"/>
+      <rule symbol="5" key="{4f92aea1-46ea-40bd-91e8-1f71bc3cabf3}" label="rampa" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'r'"/>
+      <rule symbol="6" key="{7446eccf-4e2d-4a13-8113-61a5ba239d4c}" label="wjazd do podziemia" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'j'"/>
+      <rule symbol="7" key="{89f057ff-ee2b-43fb-b41f-67e5a58b4ef6}" label="podjazd dla osób niepełnosprawnych" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'd'"/>
+      <rule symbol="8" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{ad032e9c-2265-467e-8dfa-955c73d42f67}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c79622d4-ffff-4c84-af07-e5f4763de3d0}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{95beded3-18e9-4da3-9474-740f4d6ed4ad}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.5;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{a9d7e894-4f0c-426c-952e-2e88633e9228}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" id="{3ba8fdf4-fce5-47cc-bb39-8738681db6bd}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MapUnit" />
-            <Option name="interval" type="QString" value="0.5" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="Interval" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option name="average_angle_length" value="4" type="QString"/>
+            <Option name="average_angle_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="average_angle_unit" value="MapUnit" type="QString"/>
+            <Option name="interval" value="0.5" type="QString"/>
+            <Option name="interval_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="interval_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_along_line" value="0" type="QString"/>
+            <Option name="offset_along_line_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="offset_along_line_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="place_on_every_part" value="true" type="bool"/>
+            <Option name="placements" value="Interval" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="rotate" value="1" type="QString"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MapUnit" k="average_angle_unit" />
-          <prop v="0.5" k="interval" />
-          <prop v="3x:2500,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="Interval" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@2@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{dd4d3d21-e7f9-4afb-ae8b-ea5862954f81}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="35,35,35,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.09" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.09" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.09" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.09" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="35,35,35,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.09" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.09" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c4a26957-0ce9-42b2-8f74-736eb41a6fe2}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{785ede74-c8c1-4e9a-b70d-784ccf78b124}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@3@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@3@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{f083fe83-aa52-45c4-90e2-2753746a1c75}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="35,35,35,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="35,35,35,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{6f42d63e-0a3e-4d79-adf7-9f4d6bbd329b}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="35,35,35,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="35,35,35,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{25ff0950-ae2f-4f46-ac84-ca38bf340466}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{71957e88-d089-4d86-b970-e25f8f09ba29}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{ee3f8b0d-44da-4c85-9ac6-38854ecbda6b}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="PointPatternFill" pass="0" enabled="1">
+        <layer class="PointPatternFill" id="{24f8688e-60a0-4e41-b68d-d4f15b9bddc9}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="angle" type="double" value="0" />
-            <Option name="clip_mode" type="QString" value="shape" />
-            <Option name="coordinate_reference" type="QString" value="feature" />
-            <Option name="displacement_x" type="QString" value="0.5" />
-            <Option name="displacement_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="displacement_x_unit" type="QString" value="MapUnit" />
-            <Option name="displacement_y" type="QString" value="0" />
-            <Option name="displacement_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="displacement_y_unit" type="QString" value="MapUnit" />
-            <Option name="distance_x" type="QString" value="1" />
-            <Option name="distance_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="distance_x_unit" type="QString" value="MapUnit" />
-            <Option name="distance_y" type="QString" value="1" />
-            <Option name="distance_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="distance_y_unit" type="QString" value="MapUnit" />
-            <Option name="offset_x" type="QString" value="0" />
-            <Option name="offset_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_x_unit" type="QString" value="MapUnit" />
-            <Option name="offset_y" type="QString" value="0" />
-            <Option name="offset_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_y_unit" type="QString" value="MapUnit" />
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="random_deviation_x" type="QString" value="0" />
-            <Option name="random_deviation_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="random_deviation_x_unit" type="QString" value="MM" />
-            <Option name="random_deviation_y" type="QString" value="0" />
-            <Option name="random_deviation_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="random_deviation_y_unit" type="QString" value="MM" />
-            <Option name="seed" type="QString" value="923063909" />
+            <Option name="angle" value="0" type="double"/>
+            <Option name="clip_mode" value="shape" type="QString"/>
+            <Option name="coordinate_reference" value="feature" type="QString"/>
+            <Option name="displacement_x" value="0.5" type="QString"/>
+            <Option name="displacement_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_x_unit" value="MapUnit" type="QString"/>
+            <Option name="displacement_y" value="0" type="QString"/>
+            <Option name="displacement_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_y_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_x" value="1" type="QString"/>
+            <Option name="distance_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_x_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_y" value="1" type="QString"/>
+            <Option name="distance_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_y_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_x" value="0" type="QString"/>
+            <Option name="offset_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_x_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_y" value="0" type="QString"/>
+            <Option name="offset_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_y_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="random_deviation_x" value="0" type="QString"/>
+            <Option name="random_deviation_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_x_unit" value="MM" type="QString"/>
+            <Option name="random_deviation_y" value="0" type="QString"/>
+            <Option name="random_deviation_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_y_unit" value="MM" type="QString"/>
+            <Option name="seed" value="923063909" type="QString"/>
           </Option>
-          <prop v="0" k="angle" />
-          <prop v="shape" k="clip_mode" />
-          <prop v="feature" k="coordinate_reference" />
-          <prop v="0.5" k="displacement_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="displacement_x_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_x_unit" />
-          <prop v="0" k="displacement_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="displacement_y_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_y_unit" />
-          <prop v="1" k="distance_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="distance_x_map_unit_scale" />
-          <prop v="MapUnit" k="distance_x_unit" />
-          <prop v="1" k="distance_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="distance_y_map_unit_scale" />
-          <prop v="MapUnit" k="distance_y_unit" />
-          <prop v="0" k="offset_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_x_map_unit_scale" />
-          <prop v="MapUnit" k="offset_x_unit" />
-          <prop v="0" k="offset_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_y_map_unit_scale" />
-          <prop v="MapUnit" k="offset_y_unit" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="0" k="random_deviation_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="random_deviation_x_map_unit_scale" />
-          <prop v="MM" k="random_deviation_x_unit" />
-          <prop v="0" k="random_deviation_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="random_deviation_y_map_unit_scale" />
-          <prop v="MM" k="random_deviation_y_unit" />
-          <prop v="923063909" k="seed" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@6@1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{33c5b06d-6e99-4e89-b22e-98f603164c65}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="35,35,35,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.09" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.09" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.09" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.09" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="35,35,35,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.09" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.09" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{7fbdba60-3970-4529-8168-daa72f64153e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{d7c63dbb-d4cd-413b-8381-25a87d57413c}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.05" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.05" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:2500,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.05" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{c6bf984f-d243-4efb-9d73-601f5f45b682}">
       <settings calloutType="simple">
-        <text-style fontWeight="50" fontSizeUnit="Point" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="" allowHtml="0" fieldName="" fontSize="10" fontItalic="0" fontFamily="MS Shell Dlg 2" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="0">
-          <families />
-          <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-          <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-          <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-            <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+        <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="Point" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="" fieldName="" isExpression="0" fontSize="10" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="MS Shell Dlg 2" legendString="Aa" fontSizeMapUnitScale="3x:0,0,0,0,0,0" tabStopDistance="80">
+          <families/>
+          <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+          <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+          <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+            <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" />
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+              <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                 <Option type="Map">
-                  <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                  <Option name="color" type="QString" value="255,255,255,255" />
-                  <Option name="joinstyle" type="QString" value="bevel" />
-                  <Option name="offset" type="QString" value="0,0" />
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                  <Option name="offset_unit" type="QString" value="MM" />
-                  <Option name="outline_color" type="QString" value="128,128,128,255" />
-                  <Option name="outline_style" type="QString" value="no" />
-                  <Option name="outline_width" type="QString" value="0" />
-                  <Option name="outline_width_unit" type="QString" value="MM" />
-                  <Option name="style" type="QString" value="solid" />
+                  <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="offset" value="0,0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                  <Option name="outline_style" value="no" type="QString"/>
+                  <Option name="outline_width" value="0" type="QString"/>
+                  <Option name="outline_width_unit" value="MM" type="QString"/>
+                  <Option name="style" value="solid" type="QString"/>
                 </Option>
-                <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                <prop v="255,255,255,255" k="color" />
-                <prop v="bevel" k="joinstyle" />
-                <prop v="0,0" k="offset" />
-                <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                <prop v="MM" k="offset_unit" />
-                <prop v="128,128,128,255" k="outline_color" />
-                <prop v="no" k="outline_style" />
-                <prop v="0" k="outline_width" />
-                <prop v="MM" k="outline_width_unit" />
-                <prop v="solid" k="style" />
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </background>
-          <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+          <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
-          <substitutions />
+          <substitutions/>
         </text-style>
-        <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-        <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="0" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="UnknownGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-        <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="0" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+        <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+        <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="PreventOverlap" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="0" distUnits="MM" prioritization="PreferCloser" layerType="UnknownGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+        <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="0" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
         <dd_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </dd_properties>
         <callout type="simple">
           <Option type="Map">
-            <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-            <Option name="blendMode" type="int" value="0" />
+            <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+            <Option name="blendMode" value="0" type="int"/>
             <Option name="ddProperties" type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
-            <Option name="drawToAllParts" type="bool" value="false" />
-            <Option name="enabled" type="QString" value="0" />
-            <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-            <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-            <Option name="minLength" type="double" value="0" />
-            <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="minLengthUnit" type="QString" value="MM" />
-            <Option name="offsetFromAnchor" type="double" value="0" />
-            <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-            <Option name="offsetFromLabel" type="double" value="0" />
-            <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+            <Option name="drawToAllParts" value="false" type="bool"/>
+            <Option name="enabled" value="0" type="QString"/>
+            <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+            <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{9deafbce-780f-40b8-b024-bb178e17ae06}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+            <Option name="minLength" value="0" type="double"/>
+            <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="minLengthUnit" value="MM" type="QString"/>
+            <Option name="offsetFromAnchor" value="0" type="double"/>
+            <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+            <Option name="offsetFromLabel" value="0" type="double"/>
+            <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
           </Option>
         </callout>
       </settings>
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'r'" key="{fc9e0be7-717c-4636-95bd-b7586cc52f83}">
+      <rule key="{fc9e0be7-717c-4636-95bd-b7586cc52f83}" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'r'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'rmp'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'rmp'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="114,155,111,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="35,35,35,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="114,155,111,255,rgb:0.44705882352941179,0.60784313725490191,0.43529411764705883,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="114,155,111,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="35,35,35,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{75357b04-519c-4811-b156-ad1008cf0bcf}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule filter="rodzajObiektuZwiazanegoZBudynkiem  = 'd'" key="{00b57f7c-30ee-419f-8b3d-862966a61627}">
+      <rule key="{00b57f7c-30ee-419f-8b3d-862966a61627}" filter="rodzajObiektuZwiazanegoZBudynkiem  = 'd'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'n'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'n'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="190,207,80,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="35,35,35,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="190,207,80,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="35,35,35,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{32143c42-978f-4e41-889b-f2e8fe67ede1}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="QString" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/500/polygon/OT_Budowle.qml
+++ b/stylization/500/polygon/OT_Budowle.qml
@@ -1,3226 +1,2452 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.40.4-Bratislava" styleCategories="Symbology|Labeling" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" forceraster="0" symbollevels="0" referencescale="-1">
     <rules key="{e5e65104-337a-4815-b02f-0ddfff356ac4}">
-      <rule filter="rodzajBudowli = 'a'" symbol="0" label="wiata" key="{0d6cbf7f-fb2b-42e3-9ee9-d811d589ab97}" />
-      <rule filter="rodzajBudowli = 'm'" symbol="1" label="smietnik" key="{5e47f501-c56c-4742-a8f5-ecf2960015b3}" />
-      <rule filter="rodzajBudowli = 'n'" symbol="2" label="sciana oporowa" key="{8e900c8b-b8b2-469b-82e7-309927dabbb8}" />
-      <rule filter="rodzajBudowli = 'd'" symbol="3" label="podpora" key="{c5271956-6a23-4529-b76c-57164f43bfc4}" />
-      <rule filter="rodzajBudowli = 't'" symbol="4" label="fontanna" key="{5a0da85a-0e1f-4c86-896d-6860fcc77935}" />
-      <rule filter="rodzajBudowli = 'p'" symbol="5" label="pomnik" key="{addac1aa-9b8c-4d05-a882-01f5d76de3c4}" />
-      <rule filter="rodzajBudowli = 'r'" symbol="6" label="ruina zabytkowa" key="{789bb36c-ea71-4987-a904-c5b624e45627}" />
-      <rule filter="rodzajBudowli = 'c'" symbol="7" label="wieża ciśnień" key="{7ed59ac0-0595-41f9-83e6-c87f012c11c0}" />
-      <rule filter="rodzajBudowli = 'z'" symbol="8" label="wieża przeciwpożarowa" key="{e8833998-643f-4812-b40d-7dec1a6fb35e}" />
-      <rule filter="rodzajBudowli = 's'" symbol="9" label="wieża szybu kopalnianego" key="{7533e866-043c-4a66-9867-139e681971d1}" />
-      <rule filter="rodzajBudowli = 'w'" symbol="10" label="wieża widokowa" key="{88f48392-dbc9-4f5a-945a-65beeeb0b490}" />
-      <rule filter="rodzajBudowli = 'b'" symbol="11" label="zbiornik, silos" key="{aa5b6cdb-0727-47de-bd09-0ec88ed11ae4}" />
-      <rule filter="rodzajBudowli = 'k'" symbol="12" label="chłodnia kominowa" key="{0d84f067-e65b-4c0a-af2c-4875e0495ffd}" />
-      <rule filter="rodzajBudowli = 'o'" symbol="13" label="komin przemysłowy" key="{a9321043-4866-4095-a513-0bcedabef524}" />
-      <rule filter="rodzajBudowli = 'i'" symbol="14" label="inna budowla" key="{cc728e06-74a6-463c-93a6-dc175d0c283b}" />
-      <rule filter="ELSE" symbol="15" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" />
+      <rule symbol="0" filter="rodzajBudowli = 'a'" label="wiata" key="{0d6cbf7f-fb2b-42e3-9ee9-d811d589ab97}"/>
+      <rule symbol="1" filter="rodzajBudowli = 'm'" label="smietnik" key="{5e47f501-c56c-4742-a8f5-ecf2960015b3}"/>
+      <rule symbol="2" filter="rodzajBudowli = 'n'" label="sciana oporowa" key="{8e900c8b-b8b2-469b-82e7-309927dabbb8}"/>
+      <rule symbol="3" filter="rodzajBudowli = 'd'" label="podpora" key="{c5271956-6a23-4529-b76c-57164f43bfc4}"/>
+      <rule symbol="4" filter="rodzajBudowli = 't'" label="fontanna" key="{5a0da85a-0e1f-4c86-896d-6860fcc77935}"/>
+      <rule symbol="5" filter="rodzajBudowli = 'p'" label="pomnik" key="{addac1aa-9b8c-4d05-a882-01f5d76de3c4}"/>
+      <rule symbol="6" filter="rodzajBudowli = 'r'" label="ruina zabytkowa" key="{789bb36c-ea71-4987-a904-c5b624e45627}"/>
+      <rule symbol="7" filter="rodzajBudowli = 'c'" label="wieża ciśnień" key="{7ed59ac0-0595-41f9-83e6-c87f012c11c0}"/>
+      <rule symbol="8" filter="rodzajBudowli = 'z'" label="wieża przeciwpożarowa" key="{e8833998-643f-4812-b40d-7dec1a6fb35e}"/>
+      <rule symbol="9" filter="rodzajBudowli = 's'" label="wieża szybu kopalnianego" key="{7533e866-043c-4a66-9867-139e681971d1}"/>
+      <rule symbol="10" filter="rodzajBudowli = 'w'" label="wieża widokowa" key="{88f48392-dbc9-4f5a-945a-65beeeb0b490}"/>
+      <rule symbol="11" filter="rodzajBudowli = 'b'" label="zbiornik, silos" key="{aa5b6cdb-0727-47de-bd09-0ec88ed11ae4}"/>
+      <rule symbol="12" filter="rodzajBudowli = 'k'" label="chłodnia kominowa" key="{0d84f067-e65b-4c0a-af2c-4875e0495ffd}"/>
+      <rule symbol="13" filter="rodzajBudowli = 'o'" label="komin przemysłowy" key="{a9321043-4866-4095-a513-0bcedabef524}"/>
+      <rule symbol="14" filter="rodzajBudowli = 'i'" label="inna budowla" key="{cc728e06-74a6-463c-93a6-dc175d0c283b}"/>
+      <rule symbol="15" filter="ELSE" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="0" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{5d140fb2-2f52-40c7-8852-cfbe71160896}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="1;0.5" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.09" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="1" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" pass="0" id="{1b8f0a50-c8d2-4d29-a82d-457ae0c62605}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MM" />
-            <Option name="interval" type="QString" value="3" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.25" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="FirstVertex" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="3" name="interval"/>
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="interval_unit"/>
+            <Option type="QString" value="0.25" name="offset"/>
+            <Option type="QString" value="0" name="offset_along_line"/>
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="FirstVertex" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MM" k="average_angle_unit" />
-          <prop v="3" k="interval" />
-          <prop v="3x:2500,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.25" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="FirstVertex" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@0@1" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" pass="0" id="{518ec31a-b1b6-4de2-93d3-a1619ccc7bbf}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="255,0,0,0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="square" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.09" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.5" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="round" name="cap_style"/>
+                <Option type="QString" value="255,0,0,0,rgb:1,0,0,0" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="round" name="joinstyle"/>
+                <Option type="QString" value="square" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.09" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="0.5" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="255,0,0,0" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="square" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.09" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.5" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" pass="0" id="{55af9a25-6206-4b4a-abd9-89941b2aad1d}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MM" />
-            <Option name="interval" type="QString" value="3" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.25" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="InnerVertices" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="3" name="interval"/>
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="interval_unit"/>
+            <Option type="QString" value="0.25" name="offset"/>
+            <Option type="QString" value="0" name="offset_along_line"/>
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="InnerVertices" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MM" k="average_angle_unit" />
-          <prop v="3" k="interval" />
-          <prop v="3x:2500,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.25" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="InnerVertices" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@2" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@0@2" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" pass="0" id="{7c018811-bbf6-4326-9865-3750bb06ffe9}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="45" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="255,0,0,0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="square" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.09" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.5" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="45" name="angle"/>
+                <Option type="QString" value="round" name="cap_style"/>
+                <Option type="QString" value="255,0,0,0,rgb:1,0,0,0" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="round" name="joinstyle"/>
+                <Option type="QString" value="square" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.09" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="0.5" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="45" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="255,0,0,0" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="square" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.09" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.5" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="1" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{96612dce-3bf5-405f-8c3a-4802d4086207}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="10" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="10" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{fc518c46-3c0e-497d-8813-ad889154c97c}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="11" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="11" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{7bd03a10-bff2-40ef-b7be-4b29ea699dbe}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.09" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="12" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="12" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{6236eae1-3d4a-4814-90a5-86ac10530f62}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="1" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.09" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="1" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="1" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{06368df0-6960-4afb-840b-d4b43177a631}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.175" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="13" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="13" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" pass="0" id="{417d8779-fc1b-435c-883e-321555051c12}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="color" type="QString" value="0,0,0,255" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,0,0,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.09" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.09" name="outline_width"/>
+            <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
           </Option>
-          <prop v="3x:2500,0,0,0.03,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,0,0,255" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,0,0,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.09" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="fillColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="fillColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="14" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="14" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{c7a48342-4c49-410f-8ebc-8d2641fe093a}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.09" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="15" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="15" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" pass="0" id="{635c4a47-245d-4419-906b-20bd625d415d}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.05" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option type="QString" value="3x:2500,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" name="color"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.05" name="outline_width"/>
+            <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
           </Option>
-          <prop v="3x:2500,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.05" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="2" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" pass="0" id="{d8b00e96-f504-4ca7-9f31-2c4c8b87456a}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option type="QString" value="Line" name="SymbolType"/>
+            <Option type="QString" value="geom_from_wkt(attribute('obliczona_geometria_500'))" name="geometryModifier"/>
+            <Option type="QString" value="MapUnit" name="units"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="line" name="@2@0" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" pass="0" id="{4ee0305b-2462-46f8-87fb-63fe73246696}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="round" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="round" name="joinstyle"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.09" name="line_width"/>
+                <Option type="QString" value="MapUnit" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{ce04089a-91a6-44a3-9809-81a37bdea82f}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.09" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="3" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{ee600b5e-de72-45cb-9556-804a357b7f34}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.09" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="4" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{29246a1f-1cc8-4ff1-a412-efc6f336f882}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="CentroidFill" pass="0" enabled="1">
+        <layer class="CentroidFill" pass="0" id="{92125cef-652e-4432-8a78-0ac554a9073d}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="clip_on_current_part_only" type="QString" value="0" />
-            <Option name="clip_points" type="QString" value="0" />
-            <Option name="point_on_all_parts" type="QString" value="1" />
-            <Option name="point_on_surface" type="QString" value="1" />
+            <Option type="QString" value="0" name="clip_on_current_part_only"/>
+            <Option type="QString" value="0" name="clip_points"/>
+            <Option type="QString" value="1" name="point_on_all_parts"/>
+            <Option type="QString" value="1" name="point_on_surface"/>
           </Option>
-          <prop v="0" k="clip_on_current_part_only" />
-          <prop v="0" k="clip_points" />
-          <prop v="1" k="point_on_all_parts" />
-          <prop v="1" k="point_on_surface" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@4@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@4@1" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SvgMarker" pass="0" enabled="1">
+            <layer class="SvgMarker" pass="0" id="{82a2afa1-e344-4eab-aea3-9abdff2069d2}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="color" type="QString" value="255,0,0,255" />
-                <Option name="fixedAspectRatio" type="QString" value="0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="name" type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMy42NzI0OTk5bW0iCiAgIGhlaWdodD0iMS4xNTkwMDc5bW0iCiAgIHZpZXdCb3g9IjAgMCAzLjY3MjQ5OTkgMS4xNTkwMDc5IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczNzI4IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPQk9PMDJfMDIuc3ZnIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpZD0ibmFtZWR2aWV3MzczMCIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMS4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAuMCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSIwIgogICAgIGlua3NjYXBlOmRvY3VtZW50LXVuaXRzPSJtbSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgaW5rc2NhcGU6em9vbT0iNDYuMjk1ODQ4IgogICAgIGlua3NjYXBlOmN4PSI3LjY4OTY3NDUiCiAgICAgaW5rc2NhcGU6Y3k9Ii0wLjQ2NDQwNDUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzc5OSIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzcyNSI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzgwMyI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzgwMSIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwNi4yODQ1NCwtMjExLjIyOTI3KSI+CiAgICA8ZwogICAgICAgaWQ9ImczNzk5IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzgwMykiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3Ni43Mjg3MDksMzIyLjI5NDM5KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwNSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcyLjQsMzExLjgpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgMCwwLjcyMDAzMTU3IC0wLjI5OTkyNzEzLDEuNDQwMDYzMSAtMC44MTU2NDIyOSwxLjk2Mzc3MDIgLTEuMDg3NzkwNywyLjI0MDEzNiAtMS40MjAwMzE2LDIuNDYxODI5NyAtMS44LDIuNiAtMi45LDMgLTQuMiwyLjcgLTQuOSwxLjgiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0icm91bmQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKICAgICAgICAgICBpZD0icGF0aDM4MDciCiAgICAgICAgICAgc29kaXBvZGk6bm9kZXR5cGVzPSJjc3NjIiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwOSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc3LjQsMzEzLjYpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTAuOCwwLjkgLTIsMS4yIC0zLjIsMC44IC00LjMsMC40IC01LC0wLjcgLTUsLTEuOCIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNTEwMjM2IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzgxMSIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_width" type="QString" value="0" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="parameters" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="1.75" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="255,0,0,255,rgb:1,0,0,1" name="color"/>
+                <Option type="QString" value="0" name="fixedAspectRatio"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMy42NzI0OTk5bW0iCiAgIGhlaWdodD0iMS4xNTkwMDc5bW0iCiAgIHZpZXdCb3g9IjAgMCAzLjY3MjQ5OTkgMS4xNTkwMDc5IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczNzI4IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPQk9PMDJfMDIuc3ZnIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpZD0ibmFtZWR2aWV3MzczMCIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMS4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAuMCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSIwIgogICAgIGlua3NjYXBlOmRvY3VtZW50LXVuaXRzPSJtbSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgaW5rc2NhcGU6em9vbT0iNDYuMjk1ODQ4IgogICAgIGlua3NjYXBlOmN4PSI3LjY4OTY3NDUiCiAgICAgaW5rc2NhcGU6Y3k9Ii0wLjQ2NDQwNDUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzc5OSIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzcyNSI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzgwMyI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzgwMSIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwNi4yODQ1NCwtMjExLjIyOTI3KSI+CiAgICA8ZwogICAgICAgaWQ9ImczNzk5IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzgwMykiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3Ni43Mjg3MDksMzIyLjI5NDM5KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwNSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcyLjQsMzExLjgpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgMCwwLjcyMDAzMTU3IC0wLjI5OTkyNzEzLDEuNDQwMDYzMSAtMC44MTU2NDIyOSwxLjk2Mzc3MDIgLTEuMDg3NzkwNywyLjI0MDEzNiAtMS40MjAwMzE2LDIuNDYxODI5NyAtMS44LDIuNiAtMi45LDMgLTQuMiwyLjcgLTQuOSwxLjgiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0icm91bmQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKICAgICAgICAgICBpZD0icGF0aDM4MDciCiAgICAgICAgICAgc29kaXBvZGk6bm9kZXR5cGVzPSJjc3NjIiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwOSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc3LjQsMzEzLjYpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTAuOCwwLjkgLTIsMS4yIC0zLjIsMC44IC00LjMsMC40IC01LC0wLjcgLTUsLTEuOCIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNTEwMjM2IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzgxMSIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option name="parameters"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="1.75" name="size"/>
+                <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="255,0,0,255" k="color" />
-              <prop v="0" k="fixedAspectRatio" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMy42NzI0OTk5bW0iCiAgIGhlaWdodD0iMS4xNTkwMDc5bW0iCiAgIHZpZXdCb3g9IjAgMCAzLjY3MjQ5OTkgMS4xNTkwMDc5IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczNzI4IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPQk9PMDJfMDIuc3ZnIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogIDxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBpZD0ibmFtZWR2aWV3MzczMCIKICAgICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMS4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6cGFnZW9wYWNpdHk9IjAuMCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSIwIgogICAgIGlua3NjYXBlOmRvY3VtZW50LXVuaXRzPSJtbSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgaW5rc2NhcGU6em9vbT0iNDYuMjk1ODQ4IgogICAgIGlua3NjYXBlOmN4PSI3LjY4OTY3NDUiCiAgICAgaW5rc2NhcGU6Y3k9Ii0wLjQ2NDQwNDUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzc5OSIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzcyNSI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzgwMyI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzgwMSIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwNi4yODQ1NCwtMjExLjIyOTI3KSI+CiAgICA8ZwogICAgICAgaWQ9ImczNzk5IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzgwMykiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3Ni43Mjg3MDksMzIyLjI5NDM5KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwNSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcyLjQsMzExLjgpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgMCwwLjcyMDAzMTU3IC0wLjI5OTkyNzEzLDEuNDQwMDYzMSAtMC44MTU2NDIyOSwxLjk2Mzc3MDIgLTEuMDg3NzkwNywyLjI0MDEzNiAtMS40MjAwMzE2LDIuNDYxODI5NyAtMS44LDIuNiAtMi45LDMgLTQuMiwyLjcgLTQuOSwxLjgiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0icm91bmQiCgkJICAgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIKCQkgICBzdHJva2UtbWl0ZXJsaW1pdD0iMS40MTQiCgkJICAgc3Ryb2tlLWRhc2hhcnJheT0ibm9uZSIKCQkgICBzdHJva2Utb3BhY2l0eT0iMSIKICAgICAgICAgICBpZD0icGF0aDM4MDciCiAgICAgICAgICAgc29kaXBvZGk6bm9kZXR5cGVzPSJjc3NjIiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzgwOSIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc3LjQsMzEzLjYpIj4KICAgICAgICA8cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTAuOCwwLjkgLTIsMS4yIC0zLjIsMC44IC00LjMsMC40IC01LC0wLjcgLTUsLTEuOCIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNTEwMjM2IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzgxMSIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="0" k="outline_width" />
-              <prop v="3x:2500,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="" k="parameters" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="1.75" k="size" />
-              <prop v="3x:2500,0,0,0.03,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="5" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{baec6bb2-866e-426d-9fe4-7da43010f18d}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="CentroidFill" pass="0" enabled="1">
+        <layer class="CentroidFill" pass="0" id="{83fe0258-0b19-4e55-bd12-d3ad6f7b869f}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="clip_on_current_part_only" type="QString" value="0" />
-            <Option name="clip_points" type="QString" value="0" />
-            <Option name="point_on_all_parts" type="QString" value="1" />
-            <Option name="point_on_surface" type="QString" value="1" />
+            <Option type="QString" value="0" name="clip_on_current_part_only"/>
+            <Option type="QString" value="0" name="clip_points"/>
+            <Option type="QString" value="1" name="point_on_all_parts"/>
+            <Option type="QString" value="1" name="point_on_surface"/>
           </Option>
-          <prop v="0" k="clip_on_current_part_only" />
-          <prop v="0" k="clip_points" />
-          <prop v="1" k="point_on_all_parts" />
-          <prop v="1" k="point_on_surface" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@5@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol force_rhr="0" is_animated="0" type="marker" name="@5@1" alpha="1" clip_to_extent="1" frame_rate="10">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SvgMarker" pass="0" enabled="1">
+            <layer class="SvgMarker" pass="0" id="{7ba2d34f-d7ad-4936-aba8-b9ae452d1feb}" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="color" type="QString" value="255,0,0,255" />
-                <Option name="fixedAspectRatio" type="QString" value="0" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="name" type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMi45OTg2MTFtbSIKICAgaGVpZ2h0PSIzLjE3ODYxMW1tIgogICB2aWV3Qm94PSIwIDAgMi45OTg2MTEgMy4xNzg2MTExIgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczODQ1IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPVERQLnN2ZyIKICAgeG1sbnM6aW5rc2NhcGU9Imh0dHA6Ly93d3cuaW5rc2NhcGUub3JnL25hbWVzcGFjZXMvaW5rc2NhcGUiCiAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICB4bWxuczpzdmc9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzM4NDciCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIgogICAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICAgIGJvcmRlcm9wYWNpdHk9IjEuMCIKICAgICBpbmtzY2FwZTpwYWdlc2hhZG93PSIyIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwLjAiCiAgICAgaW5rc2NhcGU6cGFnZWNoZWNrZXJib2FyZD0iMCIKICAgICBpbmtzY2FwZTpkb2N1bWVudC11bml0cz0ibW0iCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGlua3NjYXBlOnpvb209IjQ1LjI1NDgzNCIKICAgICBpbmtzY2FwZTpjeD0iMi4xMjEzMjAzIgogICAgIGlua3NjYXBlOmN5PSI1LjA5MzM3ODUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzkzNCIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzg0MiI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzkyMCI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzkxOCIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwMS40OTk0NiwtMjEwLjU1MzU1KSI+CiAgICA8ZwogICAgICAgaWQ9ImczOTE2IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzkyMCkiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3My4yMjk0NjYsMzIwLjE4MTA1KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzkyMiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYzLjYsMzAyKSI+CiAgICAgICAgPHBhdGgKICAgICAgICAgICBkPSJNIDAsMCBIIDguNSIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNTEwMjM2IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJidXR0IgoJCSAgIHN0cm9rZS1saW5lam9pbj0icm91bmQiCgkJICAgc3Ryb2tlLW1pdGVybGltaXQ9IjEuNDE0IgoJCSAgIHN0cm9rZS1kYXNoYXJyYXk9Im5vbmUiCgkJICAgc3Ryb2tlLW9wYWNpdHk9IjEiCiAgICAgICAgICAgaWQ9InBhdGgzOTI0IiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzkyNiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcwLDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgViA2LjIiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkyOCIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MzAiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2NS43LDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgViA2LjIiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkzMiIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MzQiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2NS43LDMwOC4yKSI+CiAgICAgICAgPHBhdGgKICAgICAgICAgICBkPSJNIDAsMCBDIC0wLjEsMS4yIDAuOSwyLjMgMi4yLDIuMyAzLjQsMi4zIDQuNCwxLjIgNC4zLDAiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkzNiIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_width" type="QString" value="0" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="parameters" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="1.49931" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="255,0,0,255,rgb:1,0,0,1" name="color"/>
+                <Option type="QString" value="0" name="fixedAspectRatio"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMi45OTg2MTFtbSIKICAgaGVpZ2h0PSIzLjE3ODYxMW1tIgogICB2aWV3Qm94PSIwIDAgMi45OTg2MTEgMy4xNzg2MTExIgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczODQ1IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPVERQLnN2ZyIKICAgeG1sbnM6aW5rc2NhcGU9Imh0dHA6Ly93d3cuaW5rc2NhcGUub3JnL25hbWVzcGFjZXMvaW5rc2NhcGUiCiAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICB4bWxuczpzdmc9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzM4NDciCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIgogICAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICAgIGJvcmRlcm9wYWNpdHk9IjEuMCIKICAgICBpbmtzY2FwZTpwYWdlc2hhZG93PSIyIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwLjAiCiAgICAgaW5rc2NhcGU6cGFnZWNoZWNrZXJib2FyZD0iMCIKICAgICBpbmtzY2FwZTpkb2N1bWVudC11bml0cz0ibW0iCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGlua3NjYXBlOnpvb209IjQ1LjI1NDgzNCIKICAgICBpbmtzY2FwZTpjeD0iMi4xMjEzMjAzIgogICAgIGlua3NjYXBlOmN5PSI1LjA5MzM3ODUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzkzNCIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzg0MiI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzkyMCI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzkxOCIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwMS40OTk0NiwtMjEwLjU1MzU1KSI+CiAgICA8ZwogICAgICAgaWQ9ImczOTE2IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzkyMCkiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3My4yMjk0NjYsMzIwLjE4MTA1KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzkyMiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYzLjYsMzAyKSI+CiAgICAgICAgPHBhdGgKICAgICAgICAgICBkPSJNIDAsMCBIIDguNSIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNTEwMjM2IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJidXR0IgoJCSAgIHN0cm9rZS1saW5lam9pbj0icm91bmQiCgkJICAgc3Ryb2tlLW1pdGVybGltaXQ9IjEuNDE0IgoJCSAgIHN0cm9rZS1kYXNoYXJyYXk9Im5vbmUiCgkJICAgc3Ryb2tlLW9wYWNpdHk9IjEiCiAgICAgICAgICAgaWQ9InBhdGgzOTI0IiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzkyNiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcwLDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgViA2LjIiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkyOCIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MzAiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2NS43LDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgViA2LjIiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkzMiIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MzQiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2NS43LDMwOC4yKSI+CiAgICAgICAgPHBhdGgKICAgICAgICAgICBkPSJNIDAsMCBDIC0wLjEsMS4yIDAuOSwyLjMgMi4yLDIuMyAzLjQsMi4zIDQuNCwxLjIgNC4zLDAiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkzNiIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="offset_unit"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="outline_width_unit"/>
+                <Option name="parameters"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="1.49931" name="size"/>
+                <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MapUnit" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="255,0,0,255" k="color" />
-              <prop v="0" k="fixedAspectRatio" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="base64:PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB3aWR0aD0iMi45OTg2MTFtbSIKICAgaGVpZ2h0PSIzLjE3ODYxMW1tIgogICB2aWV3Qm94PSIwIDAgMi45OTg2MTEgMy4xNzg2MTExIgogICB2ZXJzaW9uPSIxLjEiCiAgIGlkPSJzdmczODQ1IgogICBpbmtzY2FwZTp2ZXJzaW9uPSIxLjEgKGM2OGUyMmMzODcsIDIwMjEtMDUtMjMpIgogICBzb2RpcG9kaTpkb2NuYW1lPSJPVERQLnN2ZyIKICAgeG1sbnM6aW5rc2NhcGU9Imh0dHA6Ly93d3cuaW5rc2NhcGUub3JnL25hbWVzcGFjZXMvaW5rc2NhcGUiCiAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICB4bWxuczpzdmc9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9Im5hbWVkdmlldzM4NDciCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIgogICAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICAgIGJvcmRlcm9wYWNpdHk9IjEuMCIKICAgICBpbmtzY2FwZTpwYWdlc2hhZG93PSIyIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwLjAiCiAgICAgaW5rc2NhcGU6cGFnZWNoZWNrZXJib2FyZD0iMCIKICAgICBpbmtzY2FwZTpkb2N1bWVudC11bml0cz0ibW0iCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGlua3NjYXBlOnpvb209IjQ1LjI1NDgzNCIKICAgICBpbmtzY2FwZTpjeD0iMi4xMjEzMjAzIgogICAgIGlua3NjYXBlOmN5PSI1LjA5MzM3ODUiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwMDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjEzNDEiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjEwMzIiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJnMzkzNCIgLz4KICA8ZGVmcwogICAgIGlkPSJkZWZzMzg0MiI+CiAgICA8Y2xpcFBhdGgKICAgICAgIGNsaXBQYXRoVW5pdHM9InVzZXJTcGFjZU9uVXNlIgogICAgICAgaWQ9ImNsaXBQYXRoMzkyMCI+CiAgICAgIDxwYXRoCiAgICAgICAgIGQ9Im0gMzMzLjA3NywyNzQuODY3IGggMTI1Ljg0NiB2IDYyLjI2NiBIIDMzMy4wNzcgdiAtNjIuMjY2IgogICAgICAgICBjbGlwLXJ1bGU9ImV2ZW5vZGQiCiAgICAgICAgIGlkPSJwYXRoMzkxOCIgLz4KICAgIDwvY2xpcFBhdGg+CiAgPC9kZWZzPgogIDxnCiAgICAgaW5rc2NhcGU6bGFiZWw9IldhcnN0d2EgMSIKICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgIGlkPSJsYXllcjEiCiAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwMS40OTk0NiwtMjEwLjU1MzU1KSI+CiAgICA8ZwogICAgICAgaWQ9ImczOTE2IgogICAgICAgY2xpcC1wYXRoPSJ1cmwoI2NsaXBQYXRoMzkyMCkiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLjM1Mjc3Nzc3LDAsMCwtMC4zNTI3Nzc3Nyw3My4yMjk0NjYsMzIwLjE4MTA1KSI+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzkyMiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYzLjYsMzAyKSI+CiAgICAgICAgPHBhdGgKICAgICAgICAgICBkPSJNIDAsMCBIIDguNSIKCQkgICBmaWxsPSJub25lIgoJCSAgIHN0cm9rZT0icGFyYW0ob3V0bGluZSkgIzAwMCIKCQkgICBzdHJva2Utd2lkdGg9IjAuNTEwMjM2IgoJCSAgIHN0cm9rZS1saW5lY2FwPSJidXR0IgoJCSAgIHN0cm9rZS1saW5lam9pbj0icm91bmQiCgkJICAgc3Ryb2tlLW1pdGVybGltaXQ9IjEuNDE0IgoJCSAgIHN0cm9rZS1kYXNoYXJyYXk9Im5vbmUiCgkJICAgc3Ryb2tlLW9wYWNpdHk9IjEiCiAgICAgICAgICAgaWQ9InBhdGgzOTI0IiAvPgogICAgICA8L2c+CiAgICAgIDxnCiAgICAgICAgIGlkPSJnMzkyNiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzcwLDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgViA2LjIiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkyOCIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MzAiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2NS43LDMwMikiPgogICAgICAgIDxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgViA2LjIiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkzMiIgLz4KICAgICAgPC9nPgogICAgICA8ZwogICAgICAgICBpZD0iZzM5MzQiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM2NS43LDMwOC4yKSI+CiAgICAgICAgPHBhdGgKICAgICAgICAgICBkPSJNIDAsMCBDIC0wLjEsMS4yIDAuOSwyLjMgMi4yLDIuMyAzLjQsMi4zIDQuNCwxLjIgNC4zLDAiCgkJICAgZmlsbD0ibm9uZSIKCQkgICBzdHJva2U9InBhcmFtKG91dGxpbmUpICMwMDAiCgkJICAgc3Ryb2tlLXdpZHRoPSIwLjUxMDIzNiIKCQkgICBzdHJva2UtbGluZWNhcD0iYnV0dCIKCQkgICBzdHJva2UtbGluZWpvaW49InJvdW5kIgoJCSAgIHN0cm9rZS1taXRlcmxpbWl0PSIxLjQxNCIKCQkgICBzdHJva2UtZGFzaGFycmF5PSJub25lIgoJCSAgIHN0cm9rZS1vcGFjaXR5PSIxIgogICAgICAgICAgIGlkPSJwYXRoMzkzNiIgLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="0" k="outline_width" />
-              <prop v="3x:2500,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="" k="parameters" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="1.49931" k="size" />
-              <prop v="3x:2500,0,0,0.03,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
-                  <Option name="properties" type="Map">
-                    <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                  <Option type="QString" value="" name="name"/>
+                  <Option type="Map" name="properties">
+                    <Option type="Map" name="outlineColor">
+                      <Option type="bool" value="false" name="active"/>
+                      <Option type="QString" value="" name="expression"/>
+                      <Option type="int" value="3" name="type"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="6" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{2430ed49-a920-4e43-8411-cdf5c31e2694}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="2;1" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.25" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="2;1" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.25" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="1" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="2;1" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.25" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="7" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{5a14258a-fb97-4920-a2d5-e299dcb6cf16}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="8" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{17151924-bc95-42fe-a6ad-8622b7163e7d}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="9" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol force_rhr="0" is_animated="0" type="fill" name="9" alpha="1" clip_to_extent="1" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" pass="0" id="{767a30d8-934b-440e-b8a7-95c1fca7b5b8}" locked="0" enabled="1">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.125" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="round" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.125" name="line_width"/>
+            <Option type="QString" value="MapUnit" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MapUnit" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:2500,0,0,0.03,0,0" name="width_map_unit_scale"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.125" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="enabled">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="outlineColor">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol force_rhr="0" is_animated="0" type="fill" name="" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" id="{27fc79de-f641-48d6-b9fd-63851f0e00bd}" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{6dfa58e6-5e30-4c9a-8412-69267b68dd7d}">
       <rule description="wieża ciśnień" filter="rodzajBudowli = 'c'" key="{0744fd1e-7cf6-452a-8462-71cd7b499bf1}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'cis'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'cis'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{22590c8f-3373-4b58-9c58-810e1dd3ea63}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="wieża przeciwpożarowa" filter="rodzajBudowli = 'z'" key="{6bf52ce1-26cb-405e-9042-11431d1d666c}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'poż'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'poż'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{9fca937c-98cc-4a0d-acce-fd8b29e7d9e5}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="wieża szybu kopalnianego" filter="rodzajBudowli = 's'" key="{e7501bf6-6db5-4a84-8151-e5c74c157e9d}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'sk'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'sk'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{165b4c46-0862-4ed2-8c81-9cae161642ec}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="wieża widokowa" filter="rodzajBudowli = 'w'" key="{e82a9878-fb86-41f8-bf76-7c1dd4ad2b43}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'wid'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'wid'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{754ecdb4-a56d-42a6-a9c9-7201f986a029}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="zbiornik, silos" filter="rodzajBudowli = 'b'" key="{098abedf-b57f-4c4c-bf6f-0be14531fc2e}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'zb'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'zb'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{83c34a1c-4611-47d2-a1f6-e1922b2608f0}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="śmietnik" filter="rodzajBudowli = 'm'" key="{17b04f01-9b1a-4c25-bd99-e99bf6541c34}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'sm'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'sm'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{7efc168b-4e5d-490b-ba9e-3125536821f6}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="ruina zabytkowa" filter="rodzajBudowli = 'r'" key="{7f588905-72fa-4130-86a4-451801c8aadf}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'zab'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'zab'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{c61d77ee-404a-40ac-86f7-bca92fa727ed}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
       <rule description="inna budowla" filter="rodzajBudowli = 'i'" key="{bc85b27e-1dec-44eb-8e53-22d3ef1bec5c}">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'ib'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style fontSizeUnit="MapUnit" fontFamily="Arial" multilineHeightUnit="Percentage" fontSize="1.0417000000000001" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" multilineHeight="1" isExpression="1" textOpacity="1" legendString="Aa" fontWeight="50" fontKerning="1" namedStyle="Normal" capitalization="0" fontUnderline="0" forcedBold="0" useSubstitutions="0" textOrientation="horizontal" allowHtml="0" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" fontStrikeout="0" tabStopDistance="80" fieldName="'ib'" fontItalic="0">
+            <families/>
+            <text-buffer bufferSizeUnits="MM" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferNoFill="1" bufferDraw="0" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskedSymbolLayers="" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskType="0" maskEnabled="0" maskOpacity="1"/>
+            <background shapeRadiiX="0" shapeDraw="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeOffsetX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBlendMode="0" shapeSizeX="0" shapeSizeType="0" shapeRotationType="0" shapeRotation="0" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOpacity="1" shapeBorderWidthUnit="MM" shapeType="0" shapeSizeUnit="MM">
+              <symbol force_rhr="0" is_animated="0" type="marker" name="markerSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="125,139,143,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option type="QString" value="0" name="angle"/>
+                    <Option type="QString" value="square" name="cap_style"/>
+                    <Option type="QString" value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" name="color"/>
+                    <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="circle" name="name"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="outline_color"/>
+                    <Option type="QString" value="solid" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="diameter" name="scale_method"/>
+                    <Option type="QString" value="2" name="size"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="size_unit"/>
+                    <Option type="QString" value="1" name="vertical_anchor_point"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="125,139,143,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol force_rhr="0" is_animated="0" type="fill" name="fillSymbol" alpha="1" clip_to_extent="1" frame_rate="10">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" pass="0" id="" locked="0" enabled="1">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format rightDirectionSymbol=">" reverseDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" wrapChar="" formatNumbers="0" useMaxLineLengthForAutoWrap="1" multilineAlign="3" autoWrapLength="0" addDirectionSymbol="0" plussign="0"/>
+          <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" offsetUnits="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" lineAnchorClipping="0" geometryGenerator="" layerType="PolygonGeometry" centroidWhole="0" placementFlags="10" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" maximumDistance="0" allowDegraded="1" lineAnchorPercent="0.5" maxCurvedCharAngleIn="25" rotationAngle="0" lineAnchorTextPoint="CenterOfText" repeatDistance="0" yOffset="0" lineAnchorType="0" polygonPlacementFlags="2" dist="0" centroidInside="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" overlapHandling="AllowOverlapIfRequired" geometryGeneratorType="PointGeometry" overrunDistance="0" xOffset="0" maxCurvedCharAngleOut="-25" preserveRotation="1" geometryGeneratorEnabled="0" maximumDistanceUnit="MM" quadOffset="4" overrunDistanceUnit="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="1" prioritization="PreferCloser" repeatDistanceUnits="MM"/>
+          <rendering upsidedownLabels="0" zIndex="0" obstacleType="1" minFeatureSize="0" obstacleFactor="1" fontLimitPixelSize="0" obstacle="1" fontMinPixelSize="3" scaleMax="0" drawLabels="1" scaleVisibility="0" limitNumLabels="0" maxNumLabels="2000" scaleMin="0" fontMaxPixelSize="10000" labelPerPart="0" unplacedVisibility="0" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" type="Map">
-                <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+              <Option type="QString" value="" name="name"/>
+              <Option type="Map" name="properties">
+                <Option type="Map" name="Color">
+                  <Option type="bool" value="false" name="active"/>
+                  <Option type="QString" value="" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
-                <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                <Option type="Map" name="Show">
+                  <Option type="bool" value="true" name="active"/>
+                  <Option type="QString" value="@qmapa_auto" name="expression"/>
+                  <Option type="int" value="3" name="type"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
-              <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+              <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+              <Option type="int" value="0" name="blendMode"/>
+              <Option type="Map" name="ddProperties">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option type="bool" value="false" name="drawToAllParts"/>
+              <Option type="QString" value="0" name="enabled"/>
+              <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+              <Option type="QString" value="&lt;symbol force_rhr=&quot;0&quot; is_animated=&quot;0&quot; type=&quot;line&quot; name=&quot;symbol&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; id=&quot;{81656999-49aa-4d4d-aefd-12b845d9e8ef}&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+              <Option type="double" value="0" name="minLength"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+              <Option type="QString" value="MM" name="minLengthUnit"/>
+              <Option type="double" value="0" name="offsetFromAnchor"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+              <Option type="double" value="0" name="offsetFromLabel"/>
+              <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+              <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/500/polygon/OT_Komunikacja.qml
+++ b/stylization/500/polygon/OT_Komunikacja.qml
@@ -1,2573 +1,1994 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{6669a1a9-987c-4a77-b897-7d88a06239dd}">
-      <rule filter="rodzajObiektu = 'j'" symbol="0" label="jezdnia" key="{676c2901-c1b5-4812-be23-8a349a317223}" />
-      <rule filter="rodzajObiektu = 'c'" symbol="1" label="chodnik" key="{b2abe3b4-6246-4ca6-ba2a-57716e8794eb}" />
-      <rule filter="rodzajObiektu = 'g'" symbol="2" label="droga dla rowerów" key="{bd775299-ca07-41d8-baa9-52d4e93663b3}" />
-      <rule filter="rodzajObiektu = 'u'" symbol="3" label="obszar utwardzony" key="{3621eae1-1c3f-45d0-b9ed-8e24f36d3cf1}" />
-      <rule filter="rodzajObiektu = 'r'" symbol="4" label="rów przydrożny" key="{5321ae88-caf9-4ddc-ad8f-ca585154f399}" />
-      <rule filter="rodzajObiektu = 'z'" symbol="5" label="przepust" key="{3670bd67-354d-4d74-bf3e-1e41416c96c9}" />
-      <rule filter="rodzajObiektu = 's' " symbol="6" label="schody w ciągu komunikacyjnym" key="{e2105813-6add-453a-ac45-bb6073bd1d41}" />
-      <rule filter="rodzajObiektu = 'm'" symbol="7" label="most" key="{b73dc8b4-ff2c-452c-bc83-7109e6529ae0}" />
-      <rule filter="rodzajObiektu = 'w'" symbol="8" label="wiadukt" key="{719a022a-d6db-4f39-b56a-ca3c815ac85d}" />
-      <rule filter="rodzajObiektu = 'e'" symbol="9" label="estakada" key="{f216d891-3212-440a-a2c8-e71c7f5cff55}" />
-      <rule filter="rodzajObiektu = 'n'" symbol="10" label="peron" key="{3065ab1f-c5ad-4809-892f-4073f6223b47}" />
-      <rule filter="rodzajObiektu = 'a'" symbol="11" label="rampa" key="{27ad2c2d-ea2b-4961-b5c9-d3721fcc96f5}" />
-      <rule filter="rodzajObiektu = 'i'" symbol="12" label="inny obiekt komunikacyjny" key="{224e0e5f-d3c3-4033-addd-072e911a0e77}" />
-      <rule filter="ELSE" symbol="13" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" />
+      <rule symbol="0" key="{676c2901-c1b5-4812-be23-8a349a317223}" label="jezdnia" filter="rodzajObiektu = 'j'"/>
+      <rule symbol="1" key="{b2abe3b4-6246-4ca6-ba2a-57716e8794eb}" label="chodnik" filter="rodzajObiektu = 'c'"/>
+      <rule symbol="2" key="{bd775299-ca07-41d8-baa9-52d4e93663b3}" label="droga dla rowerów" filter="rodzajObiektu = 'g'"/>
+      <rule symbol="3" key="{3621eae1-1c3f-45d0-b9ed-8e24f36d3cf1}" label="obszar utwardzony" filter="rodzajObiektu = 'u'"/>
+      <rule symbol="4" key="{5321ae88-caf9-4ddc-ad8f-ca585154f399}" label="rów przydrożny" filter="rodzajObiektu = 'r'"/>
+      <rule symbol="5" key="{3670bd67-354d-4d74-bf3e-1e41416c96c9}" label="przepust" filter="rodzajObiektu = 'z'"/>
+      <rule symbol="6" key="{e2105813-6add-453a-ac45-bb6073bd1d41}" label="schody w ciągu komunikacyjnym" filter="rodzajObiektu = 's' "/>
+      <rule symbol="7" key="{b73dc8b4-ff2c-452c-bc83-7109e6529ae0}" label="most" filter="rodzajObiektu = 'm'"/>
+      <rule symbol="8" key="{719a022a-d6db-4f39-b56a-ca3c815ac85d}" label="wiadukt" filter="rodzajObiektu = 'w'"/>
+      <rule symbol="9" key="{f216d891-3212-440a-a2c8-e71c7f5cff55}" label="estakada" filter="rodzajObiektu = 'e'"/>
+      <rule symbol="10" key="{3065ab1f-c5ad-4809-892f-4073f6223b47}" label="peron" filter="rodzajObiektu = 'n'"/>
+      <rule symbol="11" key="{27ad2c2d-ea2b-4961-b5c9-d3721fcc96f5}" label="rampa" filter="rodzajObiektu = 'a'"/>
+      <rule symbol="12" key="{224e0e5f-d3c3-4033-addd-072e911a0e77}" label="inny obiekt komunikacyjny" filter="rodzajObiektu = 'i'"/>
+      <rule symbol="13" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{3044f4a9-f1b3-4e0c-9006-ee546cb972db}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1.5;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{6f2542e7-cff5-4f1f-a902-7aeb319243c3}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="10" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="10" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{4670d15b-5665-498f-b6ba-96810eddd001}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="11" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="11" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{f04d0ad3-b8ad-494a-86de-13d9a3c73383}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="12" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="12" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{6c0e0e23-c72b-4ac5-805c-031c4468969c}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="13" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="13" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{dcc84803-7a3c-40cd-890b-3f046fd120bc}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.05" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.05" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:2500,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.05" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{9d0bff98-68a5-46bb-8035-071d113c615e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{94a4e04a-5c85-46f8-bcf2-9d93c61db78a}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1.5;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{091a02d7-365d-4035-868d-3972310a9b18}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{684b6db6-a51a-465e-bc40-5dc2774ba1e7}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.175" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.5;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{2669f143-95e7-44f0-9566-aadc6dd37cb4}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@6@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{8f6beab3-972f-410a-b791-61931bc5103c}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{d5bd3dda-20d1-4aed-926f-76b1eb164c04}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{0489eb94-4a1f-444e-ba94-253006a3af81}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="color" type="QString" value="255,255,255,0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,0,0,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.175" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="color" value="255,255,255,0,rgb:1,1,1,0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.175" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:2500,0,0,0.03,0,0" k="border_width_map_unit_scale" />
-          <prop v="255,255,255,0" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,0,0,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.175" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c11c3201-8d84-4397-9ccb-8c02bf52db96}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.175" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="9" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="9" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{b60cf764-ea02-4db7-abfa-e147892f3863}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.175" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{20e33d7a-0d19-4d63-991a-dd7dd2b9a573}">
-      <rule description="jezdnia" filter="rodzajObiektu = 'j'" key="{33e628c2-e38e-49ec-9013-967b042a98be}">
+      <rule key="{33e628c2-e38e-49ec-9013-967b042a98be}" description="jezdnia" filter="rodzajObiektu = 'j'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'j.' + try(&quot;rodzajNawierzchni&quot;)" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'j.' + try(&quot;rodzajNawierzchni&quot;)" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{240171e3-61cf-43a9-af08-c03fc76512d3}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="chodnik" filter="rodzajObiektu = 'c'" key="{b42c4063-c0e2-4f22-8107-7dfd647d1505}">
+      <rule key="{b42c4063-c0e2-4f22-8107-7dfd647d1505}" description="chodnik" filter="rodzajObiektu = 'c'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'ch.' + try(&quot;rodzajNawierzchni&quot;)" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'ch.' + try(&quot;rodzajNawierzchni&quot;)" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{e5a92aa8-fae5-4f66-9b84-8f45e7ff7cdf}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="droga dla rowerów" filter="rodzajObiektu = 'g'" key="{311b783b-fbdd-486a-b899-127862437770}">
+      <rule key="{311b783b-fbdd-486a-b899-127862437770}" description="droga dla rowerów" filter="rodzajObiektu = 'g'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'r'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'r'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{f4132385-da53-41cd-9c44-84c313149e00}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="obszar utwardzony" filter="rodzajObiektu = 'u'" key="{b1690d45-c28a-4842-b977-f3a4f8b00c64}">
+      <rule key="{b1690d45-c28a-4842-b977-f3a4f8b00c64}" description="obszar utwardzony" filter="rodzajObiektu = 'u'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="try(&quot;rodzajNawierzchni&quot;)+'.'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="try(&quot;rodzajNawierzchni&quot;)+'.'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{9328a194-2ac8-4333-8966-794c4304c123}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="rów przydrożny" filter="rodzajObiektu = 'r'" key="{b76f6e9c-0774-4598-a8ad-20fef12c1783}">
+      <rule key="{b76f6e9c-0774-4598-a8ad-20fef12c1783}" description="rów przydrożny" filter="rodzajObiektu = 'r'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'w.'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'w.'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{a4c6ab9a-16d9-40f6-bf0b-8842bebd596d}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="peron" filter="rodzajObiektu = 'n'" key="{bbf9dce6-fcf2-4af2-9175-4e4a4f3671e6}">
+      <rule key="{bbf9dce6-fcf2-4af2-9175-4e4a4f3671e6}" description="peron" filter="rodzajObiektu = 'n'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'per'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'per'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{b8b6e744-4691-44a5-9b73-65c083569bde}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="rampa" filter="rodzajObiektu = 'a'" key="{5317a0d6-f043-49cf-8dfa-92a9b52be364}">
+      <rule key="{5317a0d6-f043-49cf-8dfa-92a9b52be364}" description="rampa" filter="rodzajObiektu = 'a'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'rmp'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'rmp'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{a6dca5a8-be8e-44bc-b4e3-3a498a7790a1}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="inny obiekt komunikacyjny" filter="rodzajObiektu = 'i'" key="{711d673b-b723-4fdd-9803-a32404dbf365}">
+      <rule key="{711d673b-b723-4fdd-9803-a32404dbf365}" description="inny obiekt komunikacyjny" filter="rodzajObiektu = 'i'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'ok'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'ok'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="152,125,183,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="152,125,183,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{a3cd9481-d86d-4352-be95-8c775ef2316a}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/500/polygon/OT_ObiektTrwaleZwiazanyZBudynkami.qml
+++ b/stylization/500/polygon/OT_ObiektTrwaleZwiazanyZBudynkami.qml
@@ -1,1601 +1,1183 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{1aed1771-116e-4ba7-a492-cd5f1573b91b}">
-      <rule filter="rodzajObiektu = 't'" symbol="0" label="taras" key="{803b29a7-0c6a-401d-a3b9-6f5c5931288c}" />
-      <rule filter="rodzajObiektu = 'w'" symbol="1" label="weranda, ganek" key="{1e4318cd-a9cc-4fb4-89d5-d1ace62f0e05}" />
-      <rule filter="rodzajObiektu = 'i'" symbol="2" label="wiatrołap" key="{805755b1-0b08-48ed-8f89-32e251e5e287}" />
-      <rule filter="rodzajObiektu = 's' " symbol="3" label="schody" key="{246317b8-0501-45cd-a47d-dcee7ba7d02a}" />
-      <rule filter="rodzajObiektu = 'o'" symbol="4" label="podpora związana z budynkiem" key="{9315336e-9352-4f65-a647-a6a44f8b06a3}" />
-      <rule filter="rodzajObiektu = 'r'" symbol="5" label="rampa" key="{a3179843-9e2c-4e33-8fe6-68f95271a0b2}" />
-      <rule filter="rodzajObiektu = 'j'" symbol="6" label="wjazd do podziemia" key="{a29feab3-a9ed-4c13-87ff-df5cb8cd32a2}" />
-      <rule filter="rodzajObiektu = 'd'" symbol="7" label="podjazd dla osób niepełnosprawnych" key="{e40132d5-9fba-4968-97b2-e54f213209d9}" />
-      <rule filter="ELSE" symbol="8" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" />
+      <rule symbol="0" key="{803b29a7-0c6a-401d-a3b9-6f5c5931288c}" label="taras" filter="rodzajObiektu = 't'"/>
+      <rule symbol="1" key="{1e4318cd-a9cc-4fb4-89d5-d1ace62f0e05}" label="weranda, ganek" filter="rodzajObiektu = 'w'"/>
+      <rule symbol="2" key="{805755b1-0b08-48ed-8f89-32e251e5e287}" label="wiatrołap" filter="rodzajObiektu = 'i'"/>
+      <rule symbol="3" key="{246317b8-0501-45cd-a47d-dcee7ba7d02a}" label="schody" filter="rodzajObiektu = 's' "/>
+      <rule symbol="4" key="{9315336e-9352-4f65-a647-a6a44f8b06a3}" label="podpora związana z budynkiem" filter="rodzajObiektu = 'o'"/>
+      <rule symbol="5" key="{a3179843-9e2c-4e33-8fe6-68f95271a0b2}" label="rampa" filter="rodzajObiektu = 'r'"/>
+      <rule symbol="6" key="{a29feab3-a9ed-4c13-87ff-df5cb8cd32a2}" label="wjazd do podziemia" filter="rodzajObiektu = 'j'"/>
+      <rule symbol="7" key="{e40132d5-9fba-4968-97b2-e54f213209d9}" label="podjazd dla osób niepełnosprawnych" filter="rodzajObiektu = 'd'"/>
+      <rule symbol="8" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{978ee53f-1afa-4d1f-af5d-4d44fc4a6538}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{5e1090ac-0b8f-4fab-ac52-1e03d07301f8}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{17cc767b-ce61-4e53-bb7b-e8a31fc2c51b}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.5;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{7f2ec799-3874-414b-9188-8492a563aef5}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="MarkerLine" pass="0" enabled="1">
+        <layer class="MarkerLine" id="{f8201f03-3357-4d3a-82c3-afae4767cded}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="average_angle_length" type="QString" value="4" />
-            <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="average_angle_unit" type="QString" value="MapUnit" />
-            <Option name="interval" type="QString" value="0.5" />
-            <Option name="interval_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="interval_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0.5" />
-            <Option name="offset_along_line" type="QString" value="0" />
-            <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_along_line_unit" type="QString" value="MapUnit" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="place_on_every_part" type="bool" value="true" />
-            <Option name="placements" type="QString" value="Interval" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="rotate" type="QString" value="1" />
+            <Option name="average_angle_length" value="4" type="QString"/>
+            <Option name="average_angle_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="average_angle_unit" value="MapUnit" type="QString"/>
+            <Option name="interval" value="0.5" type="QString"/>
+            <Option name="interval_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="interval_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0.5" type="QString"/>
+            <Option name="offset_along_line" value="0" type="QString"/>
+            <Option name="offset_along_line_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="offset_along_line_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="place_on_every_part" value="true" type="bool"/>
+            <Option name="placements" value="Interval" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="rotate" value="1" type="QString"/>
           </Option>
-          <prop v="4" k="average_angle_length" />
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale" />
-          <prop v="MapUnit" k="average_angle_unit" />
-          <prop v="0.5" k="interval" />
-          <prop v="3x:2500,0,0,0,0,0" k="interval_map_unit_scale" />
-          <prop v="MapUnit" k="interval_unit" />
-          <prop v="0.5" k="offset" />
-          <prop v="0" k="offset_along_line" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_along_line_map_unit_scale" />
-          <prop v="MapUnit" k="offset_along_line_unit" />
-          <prop v="3x:2500,0,0,0,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="true" k="place_on_every_part" />
-          <prop v="Interval" k="placements" />
-          <prop v="0" k="ring_filter" />
-          <prop v="1" k="rotate" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@2@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{17561e8f-071f-4d3a-b22f-5f45c78cdd2b}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="square" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.09" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.09" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.09" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.09" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="square" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.09" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.09" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{fb20eb54-6d17-40fe-aa36-022c6f0afb22}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{40a48344-f3b5-495b-b03a-eeea0b9c2c08}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v="geom_from_wkt( &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@3@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@3@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{359b4d38-d4e3-4dd5-b315-aae3f0a39ae5}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{f9c55f91-30f4-4e3e-8b5d-c89564d78d7e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{990052ca-eecc-4660-813c-725e15fd11da}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c1b72d36-426c-40cb-9a03-52eb40344d6e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{4520d40e-aeae-431f-a9a5-edb5e4ddedd7}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer locked="0" class="PointPatternFill" pass="0" enabled="1">
+        <layer class="PointPatternFill" id="{4b1680e7-4b17-4c7d-9a39-88c0eeb4750a}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="angle" type="double" value="0" />
-            <Option name="clip_mode" type="QString" value="shape" />
-            <Option name="coordinate_reference" type="QString" value="feature" />
-            <Option name="displacement_x" type="QString" value="0.5" />
-            <Option name="displacement_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="displacement_x_unit" type="QString" value="MapUnit" />
-            <Option name="displacement_y" type="QString" value="0" />
-            <Option name="displacement_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="displacement_y_unit" type="QString" value="MapUnit" />
-            <Option name="distance_x" type="QString" value="1" />
-            <Option name="distance_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="distance_x_unit" type="QString" value="MapUnit" />
-            <Option name="distance_y" type="QString" value="1" />
-            <Option name="distance_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="distance_y_unit" type="QString" value="MapUnit" />
-            <Option name="offset_x" type="QString" value="0" />
-            <Option name="offset_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_x_unit" type="QString" value="MapUnit" />
-            <Option name="offset_y" type="QString" value="0" />
-            <Option name="offset_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_y_unit" type="QString" value="MapUnit" />
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="random_deviation_x" type="QString" value="0" />
-            <Option name="random_deviation_x_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="random_deviation_x_unit" type="QString" value="MM" />
-            <Option name="random_deviation_y" type="QString" value="0" />
-            <Option name="random_deviation_y_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="random_deviation_y_unit" type="QString" value="MM" />
-            <Option name="seed" type="QString" value="422066968" />
+            <Option name="angle" value="0" type="double"/>
+            <Option name="clip_mode" value="shape" type="QString"/>
+            <Option name="coordinate_reference" value="feature" type="QString"/>
+            <Option name="displacement_x" value="0.5" type="QString"/>
+            <Option name="displacement_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_x_unit" value="MapUnit" type="QString"/>
+            <Option name="displacement_y" value="0" type="QString"/>
+            <Option name="displacement_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="displacement_y_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_x" value="1" type="QString"/>
+            <Option name="distance_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_x_unit" value="MapUnit" type="QString"/>
+            <Option name="distance_y" value="1" type="QString"/>
+            <Option name="distance_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="distance_y_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_x" value="0" type="QString"/>
+            <Option name="offset_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_x_unit" value="MapUnit" type="QString"/>
+            <Option name="offset_y" value="0" type="QString"/>
+            <Option name="offset_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_y_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="random_deviation_x" value="0" type="QString"/>
+            <Option name="random_deviation_x_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_x_unit" value="MM" type="QString"/>
+            <Option name="random_deviation_y" value="0" type="QString"/>
+            <Option name="random_deviation_y_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="random_deviation_y_unit" value="MM" type="QString"/>
+            <Option name="seed" value="422066968" type="QString"/>
           </Option>
-          <prop v="0" k="angle" />
-          <prop v="shape" k="clip_mode" />
-          <prop v="feature" k="coordinate_reference" />
-          <prop v="0.5" k="displacement_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="displacement_x_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_x_unit" />
-          <prop v="0" k="displacement_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="displacement_y_map_unit_scale" />
-          <prop v="MapUnit" k="displacement_y_unit" />
-          <prop v="1" k="distance_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="distance_x_map_unit_scale" />
-          <prop v="MapUnit" k="distance_x_unit" />
-          <prop v="1" k="distance_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="distance_y_map_unit_scale" />
-          <prop v="MapUnit" k="distance_y_unit" />
-          <prop v="0" k="offset_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_x_map_unit_scale" />
-          <prop v="MapUnit" k="offset_x_unit" />
-          <prop v="0" k="offset_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_y_map_unit_scale" />
-          <prop v="MapUnit" k="offset_y_unit" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="outline_width_map_unit_scale" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="0" k="random_deviation_x" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="random_deviation_x_map_unit_scale" />
-          <prop v="MM" k="random_deviation_x_unit" />
-          <prop v="0" k="random_deviation_y" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="random_deviation_y_map_unit_scale" />
-          <prop v="MM" k="random_deviation_y_unit" />
-          <prop v="422066968" k="seed" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@1" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <symbol name="@6@1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+            <layer class="SimpleMarker" id="{7dea5c39-b7e3-4fec-a7b0-890645f8d4df}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0" />
-                <Option name="cap_style" type="QString" value="round" />
-                <Option name="color" type="QString" value="0,0,0,255" />
-                <Option name="horizontal_anchor_point" type="QString" value="1" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="name" type="QString" value="circle" />
-                <Option name="offset" type="QString" value="0,0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MapUnit" />
-                <Option name="outline_color" type="QString" value="0,0,0,255" />
-                <Option name="outline_style" type="QString" value="solid" />
-                <Option name="outline_width" type="QString" value="0.09" />
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="outline_width_unit" type="QString" value="MapUnit" />
-                <Option name="scale_method" type="QString" value="diameter" />
-                <Option name="size" type="QString" value="0.09" />
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="size_unit" type="QString" value="MapUnit" />
-                <Option name="vertical_anchor_point" type="QString" value="1" />
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="round" type="QString"/>
+                <Option name="color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MapUnit" type="QString"/>
+                <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.09" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="0.09" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MapUnit" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
-              <prop v="0" k="angle" />
-              <prop v="round" k="cap_style" />
-              <prop v="0,0,0,255" k="color" />
-              <prop v="1" k="horizontal_anchor_point" />
-              <prop v="round" k="joinstyle" />
-              <prop v="circle" k="name" />
-              <prop v="0,0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MapUnit" k="offset_unit" />
-              <prop v="0,0,0,255" k="outline_color" />
-              <prop v="solid" k="outline_style" />
-              <prop v="0.09" k="outline_width" />
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-              <prop v="MapUnit" k="outline_width_unit" />
-              <prop v="diameter" k="scale_method" />
-              <prop v="0.09" k="size" />
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-              <prop v="MapUnit" k="size_unit" />
-              <prop v="1" k="vertical_anchor_point" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="fillColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{5239fda8-3014-46dd-9907-261f096addd9}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{dcd9b837-04ed-4083-9abf-465fe8509e19}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.05" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.05" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:2500,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.05" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{7e724c5f-568e-4878-959f-0fc56ee9903f}">
-      <rule description="rampa" filter="rodzajObiektu = 'r'" key="{f5aac7d2-50c5-4524-b7ca-f8df0d71e827}">
+      <rule key="{f5aac7d2-50c5-4524-b7ca-f8df0d71e827}" description="rampa" filter="rodzajObiektu = 'r'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'rmp'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'rmp'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="232,113,141,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="232,113,141,255,rgb:0.90980392156862744,0.44313725490196076,0.55294117647058827,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="232,113,141,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="0" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="PreventOverlap" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="0" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{bb97c00d-9232-4b9e-9ac0-4480705dd369}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="podjazd dla osób niepełnosprawnych" filter="rodzajObiektu = 'd'" key="{c9b11434-7367-4abe-b16f-879270585116}">
+      <rule key="{c9b11434-7367-4abe-b16f-879270585116}" description="podjazd dla osób niepełnosprawnych" filter="rodzajObiektu = 'd'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'n'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'n'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="255,158,23,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="255,158,23,255,rgb:1,0.61960784313725492,0.09019607843137255,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="255,158,23,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="0" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="0" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="0" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="PreventOverlap" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="0" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="0" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{6fd338f2-eb51-44b6-9013-777168778d7c}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/500/polygon/OT_Skarpa.qml
+++ b/stylization/500/polygon/OT_Skarpa.qml
@@ -1,416 +1,328 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="0"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="0">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{fa52eebb-7997-4077-af46-9e415d571107}">
-      <rule filter="rodzajSkarpy = 'u'" symbol="0" label="skarpa umocniona" key="{3fa1983b-1cea-4354-b386-e7fe4450fd5f}" />
-      <rule filter="rodzajSkarpy = 'k'" symbol="1" label="skarpa nieumocniona" key="{fa8d07e8-341c-425b-9213-05b3d749965a}" />
-      <rule filter="ELSE" symbol="2" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" />
+      <rule symbol="0" key="{3fa1983b-1cea-4354-b386-e7fe4450fd5f}" label="skarpa umocniona" filter="rodzajSkarpy = 'u'"/>
+      <rule symbol="1" key="{fa8d07e8-341c-425b-9213-05b3d749965a}" label="skarpa nieumocniona" filter="rodzajSkarpy = 'k'"/>
+      <rule symbol="2" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{c44f2db8-ba72-42ad-a2c2-f5ad2bba056d}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@0@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{e8aefa69-4df1-49bc-a60e-f516df914dcb}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{c32f5476-ed46-4f18-b712-c3b0b3d896e6}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{9e2553b3-8bc8-48f8-b462-ec4ae29e233d}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@1@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@1@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{95a53530-5138-4b85-a84f-b8497a69a23f}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{78d0f449-9555-4a19-9acd-a0d15a8f7fe0}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{58920d41-3d9a-4c26-b393-9449113a0850}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.05" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.05" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:2500,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.05" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>

--- a/stylization/500/polygon/OT_Wody.qml
+++ b/stylization/500/polygon/OT_Wody.qml
@@ -1,2187 +1,1673 @@
-<?xml version='1.0' encoding='utf-8'?>
-<qgis version="3.24.0-Tisler" styleCategories="AllStyleCategories" labelsEnabled="1"><renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1">
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling" version="3.40.4-Bratislava" labelsEnabled="1">
+  <renderer-v2 enableorderby="0" type="RuleRenderer" symbollevels="0" referencescale="-1" forceraster="0">
     <rules key="{71582cbe-1e93-488f-89e9-bf554833455f}">
-      <rule filter="rodzajObiektu = 'p'" symbol="0" label="woda płynąca" key="{abd262f0-2c39-406a-b9b3-df9a46365db8}" />
-      <rule filter="rodzajObiektu = 's'" symbol="1" label="woda stojąca" key="{7c8976f0-1b34-4e10-a7db-d3121faefe42}" />
-      <rule filter="rodzajObiektu = 'w'" symbol="2" label="wal przeciwpowodziowy" key="{91c85476-d29e-465f-8e36-2dd231001cc0}" />
-      <rule filter="rodzajObiektu = 'm'" symbol="3" label="row melioracyjny" key="{1de5dcbc-2167-44d4-a92c-8b91a6a77764}" />
-      <rule filter="rodzajObiektu = 'j'" symbol="4" label="jaz" key="{989a9418-e9c4-4a38-9efc-7e3493323205}" />
-      <rule filter="rodzajObiektu = 'l'" symbol="5" label="śluza" key="{a45032ba-6bf8-492b-9ae9-73a3bb120dad}" />
-      <rule filter="rodzajObiektu = 'g'" symbol="6" label="grobla" key="{5a9d5ea5-0451-495a-874b-e1862da607bd}" />
-      <rule filter="rodzajObiektu = 'z'" symbol="7" label="zapora" key="{66bb1a4e-5b60-45dd-b8c4-ba6330bd611d}" />
-      <rule filter="rodzajObiektu = 't'" symbol="8" label="ostroga" key="{7eea6079-e176-4928-8e4a-f48e7b59f0bd}" />
-      <rule filter="rodzajObiektu = 'o'" symbol="9" label="pomost, molo" key="{9630ff64-f70f-4372-b921-e4b27899b092}" />
-      <rule filter="rodzajObiektu = 'i'" symbol="10" label="inny obiekt" key="{3b13d8b0-dfc3-4c23-9e93-df2c074807db}" />
-      <rule filter="ELSE" symbol="11" label="nieoznaczone" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" />
+      <rule symbol="0" key="{abd262f0-2c39-406a-b9b3-df9a46365db8}" label="woda płynąca" filter="rodzajObiektu = 'p'"/>
+      <rule symbol="1" key="{7c8976f0-1b34-4e10-a7db-d3121faefe42}" label="woda stojąca" filter="rodzajObiektu = 's'"/>
+      <rule symbol="2" key="{91c85476-d29e-465f-8e36-2dd231001cc0}" label="wal przeciwpowodziowy" filter="rodzajObiektu = 'w'"/>
+      <rule symbol="3" key="{1de5dcbc-2167-44d4-a92c-8b91a6a77764}" label="row melioracyjny" filter="rodzajObiektu = 'm'"/>
+      <rule symbol="4" key="{989a9418-e9c4-4a38-9efc-7e3493323205}" label="jaz" filter="rodzajObiektu = 'j'"/>
+      <rule symbol="5" key="{a45032ba-6bf8-492b-9ae9-73a3bb120dad}" label="śluza" filter="rodzajObiektu = 'l'"/>
+      <rule symbol="6" key="{5a9d5ea5-0451-495a-874b-e1862da607bd}" label="grobla" filter="rodzajObiektu = 'g'"/>
+      <rule symbol="7" key="{66bb1a4e-5b60-45dd-b8c4-ba6330bd611d}" label="zapora" filter="rodzajObiektu = 'z'"/>
+      <rule symbol="8" key="{7eea6079-e176-4928-8e4a-f48e7b59f0bd}" label="ostroga" filter="rodzajObiektu = 't'"/>
+      <rule symbol="9" key="{9630ff64-f70f-4372-b921-e4b27899b092}" label="pomost, molo" filter="rodzajObiektu = 'o'"/>
+      <rule symbol="10" key="{3b13d8b0-dfc3-4c23-9e93-df2c074807db}" label="inny obiekt" filter="rodzajObiektu = 'i'"/>
+      <rule symbol="11" key="{9fc44e7b-5e6b-469b-92de-cb3c5de27acf}" label="nieoznaczone" filter="ELSE"/>
     </rules>
     <symbols>
-      <symbol name="0" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{4c1035d1-263b-4aee-ae8b-d5de736aa82e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="89,217,255,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="89,217,255,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="1" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{4dd4419d-57c0-4fda-b6b8-252d8ebf5790}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="89,217,255,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="89,217,255,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="10" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="10" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{0e7fb6c5-c607-49ef-9223-9c3cfd81a2f2}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="11" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="11" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+        <layer class="SimpleFill" id="{90e705b5-0a01-445f-ba39-f2c98ca36f42}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:2500,0,0,0,0,0" />
-            <Option name="color" type="QString" value="0,85,102,178" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="offset" type="QString" value="0,0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="outline_color" type="QString" value="0,34,34,255" />
-            <Option name="outline_style" type="QString" value="solid" />
-            <Option name="outline_width" type="QString" value="0.05" />
-            <Option name="outline_width_unit" type="QString" value="MapUnit" />
-            <Option name="style" type="QString" value="solid" />
+            <Option name="border_width_map_unit_scale" value="3x:2500,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,85,102,178,rgb:0,0.33333333333333331,0.40000000000000002,0.69803921568627447" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="outline_color" value="0,34,34,255,rgb:0,0.13333333333333333,0.13333333333333333,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.05" type="QString"/>
+            <Option name="outline_width_unit" value="MapUnit" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
           </Option>
-          <prop v="3x:2500,0,0,0,0,0" k="border_width_map_unit_scale" />
-          <prop v="0,85,102,178" k="color" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0,34,34,255" k="outline_color" />
-          <prop v="solid" k="outline_style" />
-          <prop v="0.05" k="outline_width" />
-          <prop v="MapUnit" k="outline_width_unit" />
-          <prop v="solid" k="style" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="2" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{096a385a-dd58-4e32-9895-2fc4934a97b7}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@2@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@2@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{d4005323-43a0-47f8-8a42-80a831fbdc60}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{fc634919-94ba-4bb6-968c-a9f2787f5d00}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="3" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="3" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{82d00a5a-97c0-4b60-bacf-08b11dda8598}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="0.5;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MapUnit" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="0.5;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MapUnit" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="0.5;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MapUnit" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="4" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="4" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{1d48ca3d-6765-4d45-a18e-7b8f9aea49ec}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.175" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="5" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="5" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{bb9bfc87-7c54-4797-b23d-ba7f52fc0eca}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.175" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="6" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="6" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="GeometryGenerator" pass="0" enabled="1">
+        <layer class="GeometryGenerator" id="{c35dcf6e-0136-4234-bcb5-4c953595036d}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="SymbolType" type="QString" value="Line" />
-            <Option name="geometryModifier" type="QString" value=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" />
-            <Option name="units" type="QString" value="MapUnit" />
+            <Option name="SymbolType" value="Line" type="QString"/>
+            <Option name="geometryModifier" value=" geom_from_wkt( attribute('obliczona_geometria_500'))" type="QString"/>
+            <Option name="units" value="MapUnit" type="QString"/>
           </Option>
-          <prop v="Line" k="SymbolType" />
-          <prop v=" geom_from_wkt(  &quot;obliczona_geometria_500&quot; )" k="geometryModifier" />
-          <prop v="MapUnit" k="units" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@6@0" alpha="1" force_rhr="0" type="line" clip_to_extent="1">
+          <symbol name="@6@0" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+            <layer class="SimpleLine" id="{b696d75c-c141-46a2-9c9a-61e8998b8f1c}" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0" />
-                <Option name="capstyle" type="QString" value="round" />
-                <Option name="customdash" type="QString" value="5;2" />
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="customdash_unit" type="QString" value="MM" />
-                <Option name="dash_pattern_offset" type="QString" value="0" />
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-                <Option name="draw_inside_polygon" type="QString" value="0" />
-                <Option name="joinstyle" type="QString" value="round" />
-                <Option name="line_color" type="QString" value="0,0,0,255" />
-                <Option name="line_style" type="QString" value="solid" />
-                <Option name="line_width" type="QString" value="0.09" />
-                <Option name="line_width_unit" type="QString" value="MapUnit" />
-                <Option name="offset" type="QString" value="0" />
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="offset_unit" type="QString" value="MM" />
-                <Option name="ring_filter" type="QString" value="0" />
-                <Option name="trim_distance_end" type="QString" value="0" />
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_end_unit" type="QString" value="MM" />
-                <Option name="trim_distance_start" type="QString" value="0" />
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                <Option name="trim_distance_start_unit" type="QString" value="MM" />
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-                <Option name="use_custom_dash" type="QString" value="0" />
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="round" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="round" type="QString"/>
+                <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.09" type="QString"/>
+                <Option name="line_width_unit" value="MapUnit" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop v="0" k="align_dash_pattern" />
-              <prop v="round" k="capstyle" />
-              <prop v="5;2" k="customdash" />
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale" />
-              <prop v="MM" k="customdash_unit" />
-              <prop v="0" k="dash_pattern_offset" />
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-              <prop v="MM" k="dash_pattern_offset_unit" />
-              <prop v="0" k="draw_inside_polygon" />
-              <prop v="round" k="joinstyle" />
-              <prop v="0,0,0,255" k="line_color" />
-              <prop v="solid" k="line_style" />
-              <prop v="0.09" k="line_width" />
-              <prop v="MapUnit" k="line_width_unit" />
-              <prop v="0" k="offset" />
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-              <prop v="MM" k="offset_unit" />
-              <prop v="0" k="ring_filter" />
-              <prop v="0" k="trim_distance_end" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-              <prop v="MM" k="trim_distance_end_unit" />
-              <prop v="0" k="trim_distance_start" />
-              <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-              <prop v="MM" k="trim_distance_start_unit" />
-              <prop v="0" k="tweak_dash_pattern_on_corners" />
-              <prop v="0" k="use_custom_dash" />
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale" />
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value="" />
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="outlineColor" type="Map">
-                      <Option name="active" type="bool" value="false" />
-                      <Option name="expression" type="QString" value="" />
-                      <Option name="type" type="int" value="3" />
+                      <Option name="active" value="false" type="bool"/>
+                      <Option name="expression" value="" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection" />
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{7a9f23aa-da7f-400b-a8af-b3f449fc849e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="1;0.5" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MM" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="1" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="1;0.5" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="1;0.5" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MM" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="1" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
-              <Option name="properties" />
-              <Option name="type" type="QString" value="collection" />
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="7" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="7" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{968a8938-b118-4c19-8177-f9d7041f3998}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.175" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.175" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.175" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="8" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="8" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{dc8a57c6-978f-4f7d-a55d-6f620a54e22e}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MapUnit" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MapUnit" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MapUnit" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="9" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+      <symbol name="9" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value="" />
-            <Option name="properties" />
-            <Option name="type" type="QString" value="collection" />
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+        <layer class="SimpleLine" id="{946f0ae1-259b-4762-92c9-e7c2220b5abd}" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0" />
-            <Option name="capstyle" type="QString" value="round" />
-            <Option name="customdash" type="QString" value="5;2" />
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="customdash_unit" type="QString" value="MM" />
-            <Option name="dash_pattern_offset" type="QString" value="0" />
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM" />
-            <Option name="draw_inside_polygon" type="QString" value="0" />
-            <Option name="joinstyle" type="QString" value="round" />
-            <Option name="line_color" type="QString" value="0,0,0,255" />
-            <Option name="line_style" type="QString" value="solid" />
-            <Option name="line_width" type="QString" value="0.09" />
-            <Option name="line_width_unit" type="QString" value="MapUnit" />
-            <Option name="offset" type="QString" value="0" />
-            <Option name="offset_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
-            <Option name="offset_unit" type="QString" value="MapUnit" />
-            <Option name="ring_filter" type="QString" value="0" />
-            <Option name="trim_distance_end" type="QString" value="0" />
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_end_unit" type="QString" value="MM" />
-            <Option name="trim_distance_start" type="QString" value="0" />
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-            <Option name="trim_distance_start_unit" type="QString" value="MM" />
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0" />
-            <Option name="use_custom_dash" type="QString" value="0" />
-            <Option name="width_map_unit_scale" type="QString" value="3x:2500,0,0,0.03,0,0" />
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="round" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="round" type="QString"/>
+            <Option name="line_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.09" type="QString"/>
+            <Option name="line_width_unit" value="MapUnit" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
+            <Option name="offset_unit" value="MapUnit" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:2500,0,0,0.03,0,0" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern" />
-          <prop v="round" k="capstyle" />
-          <prop v="5;2" k="customdash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="customdash_map_unit_scale" />
-          <prop v="MM" k="customdash_unit" />
-          <prop v="0" k="dash_pattern_offset" />
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale" />
-          <prop v="MM" k="dash_pattern_offset_unit" />
-          <prop v="0" k="draw_inside_polygon" />
-          <prop v="round" k="joinstyle" />
-          <prop v="0,0,0,255" k="line_color" />
-          <prop v="solid" k="line_style" />
-          <prop v="0.09" k="line_width" />
-          <prop v="MapUnit" k="line_width_unit" />
-          <prop v="0" k="offset" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="offset_map_unit_scale" />
-          <prop v="MapUnit" k="offset_unit" />
-          <prop v="0" k="ring_filter" />
-          <prop v="0" k="trim_distance_end" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale" />
-          <prop v="MM" k="trim_distance_end_unit" />
-          <prop v="0" k="trim_distance_start" />
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale" />
-          <prop v="MM" k="trim_distance_start_unit" />
-          <prop v="0" k="tweak_dash_pattern_on_corners" />
-          <prop v="0" k="use_custom_dash" />
-          <prop v="3x:2500,0,0,0.03,0,0" k="width_map_unit_scale" />
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="enabled" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="outlineColor" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{87abff30-f67c-48dc-a616-b12503d277c2}" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="0,0,255,255,rgb:0,0,1,1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <labeling type="rule-based">
     <rules key="{13ba0fe7-6760-4554-8e11-cb79de8d1991}">
-      <rule description="woda płynąca" filter="rodzajObiektu = 'p'" key="{83a0892c-54f1-44be-8fc1-51da9b24fb3d}">
+      <rule key="{83a0892c-54f1-44be-8fc1-51da9b24fb3d}" description="woda płynąca" filter="rodzajObiektu = 'p'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="89,217,255,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="try(&quot;nazwaWlasna&quot;)" fontSize="1.7361" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="try(&quot;nazwaWlasna&quot;)" isExpression="1" fontSize="1.7361" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{b2ce95f8-8c89-407a-887c-f72c93496bd0}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="woda stojąca" filter="rodzajObiektu = 's'" key="{368f6d64-020c-480a-bc23-3f2dd5d284d1}">
+      <rule key="{368f6d64-020c-480a-bc23-3f2dd5d284d1}" description="woda stojąca" filter="rodzajObiektu = 's'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="89,217,255,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="case&#10; when&#10;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is not null&#10; then&#10; try( &quot;nazwaWlasna&quot; )&#10; when&#10;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is null&#10; then&#10; 'w.'&#10; end&#10; " fontSize="1.7361" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="89,217,255,255,rgb:0.34901960784313724,0.85098039215686272,1,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="case&#xa; when&#xa;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is not null&#xa; then&#xa; try( &quot;nazwaWlasna&quot; )&#xa; when&#xa;    &quot;rodzajObiektu&quot;   = 's' and try( &quot;nazwaWlasna&quot; ) is null&#xa; then&#xa; 'w.'&#xa; end&#xa; " isExpression="1" fontSize="1.7361" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{f3f4b443-6e6b-44d1-a9b6-c15e3c90a5f9}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="rów melioracyjny" filter="rodzajObiektu = 'm'" key="{53b65720-d705-40e9-92bb-11accd40d791}">
+      <rule key="{53b65720-d705-40e9-92bb-11accd40d791}" description="rów melioracyjny" filter="rodzajObiektu = 'm'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'w.'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'w.'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{36332fbb-6636-4e9b-8bd8-562f9e986b27}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="jaz" filter="rodzajObiektu = 'j'" key="{8c2c85f2-3ad3-4774-8dea-2cb5bb3a4876}">
+      <rule key="{8c2c85f2-3ad3-4774-8dea-2cb5bb3a4876}" description="jaz" filter="rodzajObiektu = 'j'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'jaz'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'jaz'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{dabb30fd-96e7-4e4b-b8b7-a5029e313c7b}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="śluza" filter="rodzajObiektu = 'l'" key="{51808255-a1a1-4261-a67c-0095abea6619}">
+      <rule key="{51808255-a1a1-4261-a67c-0095abea6619}" description="śluza" filter="rodzajObiektu = 'l'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'śl'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'śl'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{a72dc0a3-0821-4d75-8550-78fda46b114d}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
-      <rule description="pomost, molo" filter="rodzajObiektu = 'o'" key="{38851caa-873c-4595-ba9d-00d114c9616c}">
+      <rule key="{38851caa-873c-4595-ba9d-00d114c9616c}" description="pomost, molo" filter="rodzajObiektu = 'o'">
         <settings calloutType="simple">
-          <text-style fontWeight="50" fontSizeUnit="MapUnit" textColor="0,0,0,255" fontKerning="1" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" namedStyle="Normal" allowHtml="0" fieldName="'molo'" fontSize="1.0417000000000001" fontItalic="0" fontFamily="Arial" capitalization="0" fontUnderline="0" useSubstitutions="0" blendMode="0" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" previewBkgrdColor="255,255,255,255" textOpacity="1" fontWordSpacing="0" multilineHeight="1" textOrientation="horizontal" isExpression="1">
-            <families />
-            <text-buffer bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="1" bufferDraw="0" />
-            <text-mask maskSizeUnits="MM" maskSize="1.5" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskEnabled="0" maskType="0" />
-            <background shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBlendMode="0" shapeType="0" shapeBorderColor="128,128,128,255" shapeRadiiUnit="MM" shapeSizeUnit="MM" shapeSVGFile="" shapeOffsetY="0" shapeSizeY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeBorderWidth="0" shapeOpacity="1" shapeDraw="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeRadiiY="0" shapeSizeX="0" shapeBorderWidthUnit="MM">
-              <symbol name="markerSymbol" alpha="1" force_rhr="0" type="marker" clip_to_extent="1">
+          <text-style textColor="0,0,0,255,rgb:0,0,0,1" fontSizeUnit="MapUnit" forcedBold="0" useSubstitutions="0" textOpacity="1" tabStopDistanceUnit="Point" namedStyle="Normal" fieldName="'molo'" isExpression="1" fontSize="1.0417000000000001" blendMode="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontWeight="50" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontUnderline="0" forcedItalic="0" textOrientation="horizontal" fontLetterSpacing="0" multilineHeightUnit="Percentage" fontStrikeout="0" capitalization="0" fontWordSpacing="0" allowHtml="0" fontKerning="1" fontItalic="0" fontFamily="Arial" legendString="Aa" fontSizeMapUnitScale="3x:2500,0,0,0,0,0" tabStopDistance="80">
+            <families/>
+            <text-buffer bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferJoinStyle="128"/>
+            <text-mask maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSize2="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5"/>
+            <background shapeDraw="0" shapeSizeY="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRotation="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOpacity="1" shapeRadiiX="0" shapeOffsetUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetX="0" shapeRotationType="0" shapeSizeType="0" shapeSizeX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBorderWidth="0" shapeBlendMode="0" shapeRadiiY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM">
+              <symbol name="markerSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+                <layer class="SimpleMarker" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="angle" type="QString" value="0" />
-                    <Option name="cap_style" type="QString" value="square" />
-                    <Option name="color" type="QString" value="141,90,153,255" />
-                    <Option name="horizontal_anchor_point" type="QString" value="1" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="name" type="QString" value="circle" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="0,0,0,255" />
-                    <Option name="outline_style" type="QString" value="solid" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="scale_method" type="QString" value="diameter" />
-                    <Option name="size" type="QString" value="2" />
-                    <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="size_unit" type="QString" value="MM" />
-                    <Option name="vertical_anchor_point" type="QString" value="1" />
+                    <Option name="angle" value="0" type="QString"/>
+                    <Option name="cap_style" value="square" type="QString"/>
+                    <Option name="color" value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString"/>
+                    <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="name" value="circle" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="0,0,0,255,rgb:0,0,0,1" type="QString"/>
+                    <Option name="outline_style" value="solid" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="scale_method" value="diameter" type="QString"/>
+                    <Option name="size" value="2" type="QString"/>
+                    <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="size_unit" value="MM" type="QString"/>
+                    <Option name="vertical_anchor_point" value="1" type="QString"/>
                   </Option>
-                  <prop v="0" k="angle" />
-                  <prop v="square" k="cap_style" />
-                  <prop v="141,90,153,255" k="color" />
-                  <prop v="1" k="horizontal_anchor_point" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="circle" k="name" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="0,0,0,255" k="outline_color" />
-                  <prop v="solid" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="diameter" k="scale_method" />
-                  <prop v="2" k="size" />
-                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale" />
-                  <prop v="MM" k="size_unit" />
-                  <prop v="1" k="vertical_anchor_point" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol name="fillSymbol" alpha="1" force_rhr="0" type="fill" clip_to_extent="1">
+              <symbol name="fillSymbol" alpha="1" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" force_rhr="0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value="" />
-                    <Option name="properties" />
-                    <Option name="type" type="QString" value="collection" />
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
-                <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+                <layer class="SimpleFill" id="" locked="0" enabled="1" pass="0">
                   <Option type="Map">
-                    <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="color" type="QString" value="255,255,255,255" />
-                    <Option name="joinstyle" type="QString" value="bevel" />
-                    <Option name="offset" type="QString" value="0,0" />
-                    <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0" />
-                    <Option name="offset_unit" type="QString" value="MM" />
-                    <Option name="outline_color" type="QString" value="128,128,128,255" />
-                    <Option name="outline_style" type="QString" value="no" />
-                    <Option name="outline_width" type="QString" value="0" />
-                    <Option name="outline_width_unit" type="QString" value="MM" />
-                    <Option name="style" type="QString" value="solid" />
+                    <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="255,255,255,255,rgb:1,1,1,1" type="QString"/>
+                    <Option name="joinstyle" value="bevel" type="QString"/>
+                    <Option name="offset" value="0,0" type="QString"/>
+                    <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="outline_color" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString"/>
+                    <Option name="outline_style" value="no" type="QString"/>
+                    <Option name="outline_width" value="0" type="QString"/>
+                    <Option name="outline_width_unit" value="MM" type="QString"/>
+                    <Option name="style" value="solid" type="QString"/>
                   </Option>
-                  <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale" />
-                  <prop v="255,255,255,255" k="color" />
-                  <prop v="bevel" k="joinstyle" />
-                  <prop v="0,0" k="offset" />
-                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale" />
-                  <prop v="MM" k="offset_unit" />
-                  <prop v="128,128,128,255" k="outline_color" />
-                  <prop v="no" k="outline_style" />
-                  <prop v="0" k="outline_width" />
-                  <prop v="MM" k="outline_width_unit" />
-                  <prop v="solid" k="style" />
                   <data_defined_properties>
                     <Option type="Map">
-                      <Option name="name" type="QString" value="" />
-                      <Option name="properties" />
-                      <Option name="type" type="QString" value="collection" />
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
                     </Option>
                   </data_defined_properties>
                 </layer>
               </symbol>
             </background>
-            <shadow shadowOffsetUnit="MM" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowBlendMode="6" />
+            <shadow shadowOffsetDist="1" shadowOffsetUnit="MM" shadowUnder="0" shadowRadiusUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadius="1.5" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6"/>
             <dd_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </dd_properties>
-            <substitutions />
+            <substitutions/>
           </text-style>
-          <text-format decimals="3" autoWrapLength="0" leftDirectionSymbol="&lt;" rightDirectionSymbol="&gt;" wrapChar="" useMaxLineLengthForAutoWrap="1" formatNumbers="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" multilineAlign="3" addDirectionSymbol="0" plussign="0" />
-          <placement overrunDistanceUnit="MM" geometryGenerator="" centroidWhole="0" geometryGeneratorType="PointGeometry" priority="5" distUnits="MM" lineAnchorPercent="0.5" lineAnchorType="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" placementFlags="10" placement="1" fitInPolygonOnly="0" yOffset="0" repeatDistance="0" rotationUnit="AngleDegrees" layerType="PolygonGeometry" offsetType="0" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidInside="1" overrunDistance="0" lineAnchorClipping="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" quadOffset="4" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" dist="0" />
-          <rendering upsidedownLabels="0" zIndex="0" fontLimitPixelSize="0" drawLabels="1" fontMaxPixelSize="10000" maxNumLabels="2000" scaleMin="0" obstacle="1" limitNumLabels="0" labelPerPart="0" displayAll="1" scaleMax="0" scaleVisibility="0" fontMinPixelSize="3" unplacedVisibility="0" obstacleType="1" obstacleFactor="1" minFeatureSize="0" mergeLines="0" />
+          <text-format multilineAlign="3" rightDirectionSymbol=">" autoWrapLength="0" decimals="3" wrapChar="" addDirectionSymbol="0" formatNumbers="0" useMaxLineLengthForAutoWrap="1" plussign="0" reverseDirectionSymbol="0" placeDirectionSymbol="0" leftDirectionSymbol="&lt;"/>
+          <placement distMapUnitScale="3x:0,0,0,0,0,0" overlapHandling="AllowOverlapIfRequired" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" placementFlags="10" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" geometryGenerator="" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" maximumDistanceUnit="MM" placement="1" distUnits="MM" prioritization="PreferCloser" layerType="PolygonGeometry" lineAnchorType="0" lineAnchorPercent="0.5" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" maxCurvedCharAngleOut="-25" geometryGeneratorEnabled="0" priority="5" preserveRotation="1" polygonPlacementFlags="2" centroidInside="1" xOffset="0" dist="0" rotationAngle="0" offsetUnits="MM" fitInPolygonOnly="0" yOffset="0" maximumDistance="0" repeatDistanceUnits="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="1" overrunDistance="0" lineAnchorClipping="0" offsetType="0"/>
+          <rendering maxNumLabels="2000" scaleMax="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" obstacleType="1" zIndex="0" limitNumLabels="0" obstacleFactor="1" drawLabels="1" fontMinPixelSize="3" scaleMin="0" labelPerPart="0" minFeatureSize="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacle="1" mergeLines="0"/>
           <dd_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value="" />
+              <Option name="name" value="" type="QString"/>
               <Option name="properties" type="Map">
                 <Option name="Color" type="Map">
-                  <Option name="active" type="bool" value="false" />
-                  <Option name="expression" type="QString" value="" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="false" type="bool"/>
+                  <Option name="expression" value="" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
                 <Option name="Show" type="Map">
-                  <Option name="active" type="bool" value="true" />
-                  <Option name="expression" type="QString" value="@qmapa_auto" />
-                  <Option name="type" type="int" value="3" />
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="@qmapa_auto" type="QString"/>
+                  <Option name="type" value="3" type="int"/>
                 </Option>
               </Option>
-              <Option name="type" type="QString" value="collection" />
+              <Option name="type" value="collection" type="QString"/>
             </Option>
           </dd_properties>
           <callout type="simple">
             <Option type="Map">
-              <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility" />
-              <Option name="blendMode" type="int" value="0" />
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="blendMode" value="0" type="int"/>
               <Option name="ddProperties" type="Map">
-                <Option name="name" type="QString" value="" />
-                <Option name="properties" />
-                <Option name="type" type="QString" value="collection" />
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <Option name="drawToAllParts" type="bool" value="false" />
-              <Option name="enabled" type="QString" value="0" />
-              <Option name="labelAnchorPoint" type="QString" value="point_on_exterior" />
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/&gt;&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/&gt;&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/&gt;&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/&gt;&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/&gt;&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/&gt;&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/&gt;&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/&gt;&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/&gt;&lt;/Option&gt;&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/&gt;&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/&gt;&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/&gt;&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/&gt;&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/&gt;&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/&gt;&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/&gt;&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/&gt;&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/&gt;&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;" />
-              <Option name="minLength" type="double" value="0" />
-              <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="minLengthUnit" type="QString" value="MM" />
-              <Option name="offsetFromAnchor" type="double" value="0" />
-              <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromAnchorUnit" type="QString" value="MM" />
-              <Option name="offsetFromLabel" type="double" value="0" />
-              <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0" />
-              <Option name="offsetFromLabelUnit" type="QString" value="MM" />
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{2d236eca-3a80-4f93-bd81-934c2cca1930}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
             </Option>
           </callout>
         </settings>
       </rule>
     </rules>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="&quot;fid&quot;" />
-      </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0" />
-      <Option name="variableNames" type="invalid" />
-      <Option name="variableValues" type="invalid" />
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerGeometryType>2</layerGeometryType>


### PR DESCRIPTION
w przypadku braku poczatekGorySkarpy lub koniecGorySkarpy kreskowanie powodowalo bledy, poniewaz nie moglo odnalezc tych warstw. Wykonano uodpornienie - kreskowanie nie wykonuje sie jak nie ma tych obiektow, uodporniono tez symbole zeby nie bylo bledow w kodzie w przypadku braku obliczonych pol z kreskowaniem.